### PR TITLE
Enhance CLI with interactive question handling and auto-answer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ If you want a **web dashboard**, multi-agent supervision, or a **desktop control
 We are leaning further into the CLI instead of backing away from it: stronger harness defaults, fail-loud provider behavior, a richer tool surface, and stable event schemas for people building wrappers around `nca`.
 
 - Session lifecycle, events, and approvals all use the same runtime IPC (`attach`, approvals, shutdown).
+- Interactive clarification uses the `ask_question` tool: structured options, optional custom text, always a model `suggested_answer`, plus `/auto-answer` in the REPL/TUI to accept the suggestion.
 - Child sessions get **git worktrees** and explicit lineage so parallel agents do not step on each other.
 
 If you are building a control plane, the intended split is straightforward: let `nca` stay the **lean worker process**, and let tools like Paperclip or Enterprise Orchestration handle dashboards, persistence, and fleet-level coordination.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -487,6 +487,7 @@ async fn try_main() -> anyhow::Result<()> {
                             runtime.event_log_path(),
                             ipc_handle,
                             approval_pending,
+                            runtime.question_pending(),
                             None,
                         );
                         let _ = runtime.run_turn(prompt).await;
@@ -554,6 +555,7 @@ async fn try_main() -> anyhow::Result<()> {
                             runtime.event_log_path(),
                             ipc_handle,
                             approval_pending,
+                            runtime.question_pending(),
                             None,
                         );
                     }
@@ -601,6 +603,7 @@ async fn run_one_shot(
             runtime.event_log_path(),
             ipc_handle,
             approval_pending,
+            runtime.question_pending(),
             None,
         );
 
@@ -867,6 +870,7 @@ async fn resume_session(
                 runtime.event_log_path(),
                 ipc_handle,
                 approval_pending,
+                runtime.question_pending(),
                 None,
             );
         }
@@ -888,6 +892,7 @@ async fn resume_session(
                 runtime.event_log_path(),
                 ipc_handle,
                 approval_pending,
+                runtime.question_pending(),
                 None,
             );
         }

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -1,9 +1,9 @@
 use crate::prompt::NcaPrompt;
-use crate::runner::SessionRuntime;
+use crate::runner::{dispatch_question_answer, SessionRuntime};
 use crate::slash_commands::SLASH_COMMANDS;
 use crate::tui::{run_blocking, spawn_tui_bridge, DisplayBlock, TuiCmd, TuiSessionState};
 use nca_common::config::PermissionMode;
-use nca_common::event::EndReason;
+use nca_common::event::{EndReason, QuestionSelection};
 use nca_core::skills::SkillCatalog;
 use nca_runtime::memory_store::MemoryStore;
 use reedline::{Completer, Suggestion, Emacs, Vi, Reedline, Signal, FileBackedHistory};
@@ -504,6 +504,7 @@ impl Repl {
                        /diff                      Show recent file changes\n\
                        /cost                      Show token usage and cost\n\
                        /stats                     Show session statistics\n\
+                       /auto-answer               Accept suggested answer for pending ask_question\n\
                        /skills                    List discovered skills\n\
                        /memory [text]             Show or store workspace memory\n\
                        /models                    Show available models\n\
@@ -855,6 +856,28 @@ impl Repl {
                     ));
                 }
             }
+            "/auto-answer" => {
+                let from_tui = if let ReplOutput::Tui(st) = &out {
+                    st.lock()
+                        .ok()
+                        .and_then(|g| g.active_question.as_ref().map(|q| q.question_id.clone()))
+                } else {
+                    None
+                };
+                let ok = if let Some(qid) = from_tui {
+                    self.runtime
+                        .submit_question_answer(&qid, QuestionSelection::Suggested)
+                } else {
+                    self.runtime.submit_suggested_answer()
+                };
+                if ok {
+                    out.println("accepted suggested answer for pending question");
+                } else {
+                    out.eprintln(
+                        "no pending interactive question to auto-answer (use when ask_question is waiting)",
+                    );
+                }
+            }
             "/sessions" => match self.runtime.list_session_ids().await {
                 Ok(mut ids) => {
                     ids.sort();
@@ -966,12 +989,35 @@ impl Repl {
         let log_path = self.runtime.event_log_path();
         let ipc = self.runtime.take_ipc_handle();
         let approval = self.runtime.take_ipc_approval_pending();
-        let _bridge = spawn_tui_bridge(rx, log_path, ipc, approval, tui_state.clone());
+        let question = self.runtime.question_pending();
+        let _bridge = spawn_tui_bridge(
+            rx,
+            log_path,
+            ipc,
+            approval,
+            question.clone(),
+            tui_state.clone(),
+        );
+
+        // Answers must bypass the main `cmd_rx` loop: while `run_turn` is blocked inside
+        // `ask_question`, that task never receives `TuiCmd::Submit` or `QuestionAnswer`.
+        let (answer_tx, mut answer_rx) =
+            tokio::sync::mpsc::unbounded_channel::<(String, QuestionSelection)>();
+        let qp_dispatch = question.clone();
+        tokio::spawn(async move {
+            while let Some((qid, sel)) = answer_rx.recv().await {
+                let _ = dispatch_question_answer(&qp_dispatch, &qid, sel);
+            }
+        });
+        let answer_for_tui = answer_tx.clone();
+        drop(answer_tx);
 
         let (cmd_tx, mut cmd_rx) = tokio::sync::mpsc::unbounded_channel::<TuiCmd>();
         let st = tui_state.clone();
         let banner = self.run_mode;
-        let ui = tokio::task::spawn_blocking(move || run_blocking(st, cmd_tx, banner));
+        let ui = tokio::task::spawn_blocking(move || {
+            run_blocking(st, cmd_tx, Some(answer_for_tui), banner)
+        });
 
         loop {
             let cmd = cmd_rx.recv().await;
@@ -999,6 +1045,28 @@ impl Repl {
                 }
                 TuiCmd::CancelTurn => {
                     self.runtime.request_cancel();
+                }
+                TuiCmd::QuestionAnswer(selection) => {
+                    let qid = if let Ok(g) = tui_state.lock() {
+                        g.active_question
+                            .as_ref()
+                            .map(|q| q.question_id.clone())
+                    } else {
+                        None
+                    };
+                    if let Some(qid) = qid {
+                        if !self
+                            .runtime
+                            .submit_question_answer(&qid, selection)
+                        {
+                            if let Ok(mut g) = tui_state.lock() {
+                                g.push_error(
+                                    "failed to submit answer (expired or already answered)"
+                                        .into(),
+                                );
+                            }
+                        }
+                    }
                 }
                 TuiCmd::Submit(line) => {
                     let line = line.trim().to_string();

--- a/crates/cli/src/runner.rs
+++ b/crates/cli/src/runner.rs
@@ -1,5 +1,5 @@
 use nca_common::config::{NcaConfig, PermissionMode};
-use nca_common::event::{AgentEvent, EndReason};
+use nca_common::event::{AgentEvent, EndReason, QuestionSelection};
 use nca_common::session::{OrchestrationContext, SessionSnapshot};
 use nca_core::approval::ApprovalHandler;
 use nca_core::provider::ProviderError;
@@ -11,11 +11,31 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, oneshot};
 
+/// Resolve a pending `ask_question` without going through `SessionRuntime` (e.g. TUI side task
+/// while `run_turn` is blocked waiting on the same question).
+pub fn dispatch_question_answer(
+    qp: &Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>>,
+    question_id: &str,
+    selection: QuestionSelection,
+) -> bool {
+    let Some(qp) = qp else {
+        return false;
+    };
+    let Ok(mut m) = qp.lock() else {
+        return false;
+    };
+    let Some(tx) = m.remove(question_id) else {
+        return false;
+    };
+    tx.send(selection).is_ok()
+}
+
 /// Thin CLI wrapper around the runtime `Supervisor`.
 /// Keeps the same public API so existing CLI code (repl, main) works unchanged.
 pub struct SessionRuntime {
     supervisor: Supervisor,
     handle: Option<SupervisorHandle>,
+    question_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>>,
     config: NcaConfig,
 }
 
@@ -48,6 +68,41 @@ impl SessionRuntime {
         &mut self,
     ) -> Option<Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>> {
         self.handle.as_mut()?.take_approval_pending()
+    }
+
+    /// Pending `ask_question` resolvers (same map the runtime tool waits on).
+    pub fn question_pending(
+        &self,
+    ) -> Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>> {
+        self.question_pending.clone()
+    }
+
+    /// Submit an answer for the current interactive question (TUI / REPL).
+    pub fn submit_question_answer(
+        &self,
+        question_id: &str,
+        selection: QuestionSelection,
+    ) -> bool {
+        dispatch_question_answer(&self.question_pending, question_id, selection)
+    }
+
+    /// Accept the model's suggested answer when exactly one question is pending.
+    pub fn submit_suggested_answer(&self) -> bool {
+        let Some(ref qp) = self.question_pending else {
+            return false;
+        };
+        let Ok(mut m) = qp.lock() else {
+            return false;
+        };
+        let keys: Vec<String> = m.keys().cloned().collect();
+        if keys.len() != 1 {
+            return false;
+        }
+        let id = keys[0].clone();
+        let Some(tx) = m.remove(&id) else {
+            return false;
+        };
+        tx.send(QuestionSelection::Suggested).is_ok()
     }
 
     pub fn session_id(&self) -> &str {
@@ -146,10 +201,12 @@ pub async fn build_session_runtime(
     })
     .await?;
 
-    let handle = supervisor.take_handle();
+    let mut handle = supervisor.take_handle();
+    let question_pending = handle.take_question_pending();
     Ok(SessionRuntime {
         supervisor,
         handle: Some(handle),
+        question_pending,
         config,
     })
 }
@@ -169,10 +226,12 @@ pub async fn build_resumed_session_runtime(
         session_id,
     )
     .await?;
-    let handle = supervisor.take_handle();
+    let mut handle = supervisor.take_handle();
+    let question_pending = handle.take_question_pending();
     Ok(SessionRuntime {
         supervisor,
         handle: Some(handle),
+        question_pending,
         config,
     })
 }

--- a/crates/cli/src/slash_commands.rs
+++ b/crates/cli/src/slash_commands.rs
@@ -30,4 +30,5 @@ pub const SLASH_COMMANDS: &[&str] = &[
     "/diff",
     "/cost",
     "/stats",
+    "/auto-answer",
 ];

--- a/crates/cli/src/stream.rs
+++ b/crates/cli/src/stream.rs
@@ -3,14 +3,64 @@
 //! This module provides streaming event rendering with Claude Code-inspired styling.
 
 use colored::Colorize;
-use nca_common::event::{AgentEvent, EventEnvelope};
+use nca_common::event::{AgentEvent, EventEnvelope, InteractiveQuestionPayload, QuestionSelection};
 use nca_runtime::ipc::IpcHandle;
 use nca_runtime::supervisor;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::io::{self, IsTerminal, Write};
 use std::sync::atomic::{AtomicU64, Ordering};
-use tokio::sync::oneshot;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use tokio::sync::oneshot;
+
+/// Blocking stdin prompt for `--no-tui` human stream when `ask_question` runs.
+fn prompt_question_stdio(q: &InteractiveQuestionPayload) -> io::Result<QuestionSelection> {
+    let mut err = io::stderr();
+    writeln!(err)?;
+    writeln!(err, "[question] {}", q.prompt)?;
+    writeln!(err, "  [0] suggested: {}", q.suggested_answer)?;
+    for (i, o) in q.options.iter().enumerate() {
+        writeln!(err, "  [{}] ({}) {}", i + 1, o.id, o.label)?;
+    }
+    if q.allow_custom {
+        writeln!(err, "  [c] custom text")?;
+    }
+    write!(
+        err,
+        "Choice (0, 1–{}{}): ",
+        q.options.len(),
+        if q.allow_custom { ", c" } else { "" }
+    )?;
+    err.flush()?;
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    let t = line.trim();
+    if t == "0" || t.eq_ignore_ascii_case("s") {
+        return Ok(QuestionSelection::Suggested);
+    }
+    if q.allow_custom && (t.eq_ignore_ascii_case("c") || t.eq_ignore_ascii_case("custom")) {
+        write!(err, "Custom answer> ")?;
+        err.flush()?;
+        let mut custom = String::new();
+        io::stdin().read_line(&mut custom)?;
+        let custom = custom.trim().to_string();
+        if custom.is_empty() {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "empty custom answer"));
+        }
+        return Ok(QuestionSelection::Custom { text: custom });
+    }
+    if let Ok(n) = t.parse::<usize>() {
+        if n >= 1 && n <= q.options.len() {
+            return Ok(QuestionSelection::Option {
+                option_id: q.options[n - 1].id.clone(),
+            });
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "invalid choice; use 0, 1–n, or c",
+    ))
+}
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub enum StreamMode {
@@ -82,8 +132,10 @@ pub fn spawn_stream_task(
     log_path: std::path::PathBuf,
     ipc_handle: Option<IpcHandle>,
     approval_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>>,
+    question_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>>,
     cancel_tx: Option<oneshot::Sender<()>>,
 ) -> tokio::task::JoinHandle<()> {
+    let qp = question_pending.clone();
     let (event_tx_ipc, command_rx) = match ipc_handle {
         Some(h) => {
             let (etx, crx) = h.into_parts();
@@ -93,10 +145,10 @@ pub fn spawn_stream_task(
     };
 
     if let Some(crx) = command_rx {
-        supervisor::spawn_command_consumer(crx, approval_pending, cancel_tx);
+        supervisor::spawn_command_consumer(crx, approval_pending, question_pending, cancel_tx);
     }
 
-    spawn_event_fanout_task(rx, mode, log_path, event_tx_ipc)
+    spawn_event_fanout_task(rx, mode, log_path, event_tx_ipc, qp)
 }
 
 pub fn spawn_event_fanout_task(
@@ -104,6 +156,7 @@ pub fn spawn_event_fanout_task(
     mode: StreamMode,
     log_path: std::path::PathBuf,
     event_tx_ipc: Option<tokio::sync::broadcast::Sender<String>>,
+    question_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>>,
 ) -> tokio::task::JoinHandle<()> {
     let stats = StreamStats::new();
 
@@ -138,9 +191,10 @@ pub fn spawn_event_fanout_task(
 
         let mut event_id: u64 = 0;
         let mut rx = rx;
+        let qp = question_pending;
         while let Some(event) = rx.recv().await {
             event_id += 1;
-            let envelope = EventEnvelope::new(event_id, event);
+            let envelope = EventEnvelope::new(event_id, event.clone());
 
             if let Some(ref ipc) = ipc_handle_rebuilt {
                 let line = serde_json::to_string(&envelope).unwrap_or_default();
@@ -156,6 +210,25 @@ pub fn spawn_event_fanout_task(
 
             if let Some(ref cb) = on_event {
                 cb(&envelope);
+            }
+
+            if let AgentEvent::QuestionRequested { ref question } = event {
+                if matches!(mode, StreamMode::Human) && std::io::stdin().is_terminal() {
+                    if let Some(ref pending) = qp {
+                        let q = question.clone();
+                        let qid = q.question_id.clone();
+                        let pending = pending.clone();
+                        if let Ok(Ok(sel)) =
+                            tokio::task::spawn_blocking(move || prompt_question_stdio(&q)).await
+                        {
+                            if let Ok(mut m) = pending.lock() {
+                                if let Some(tx) = m.remove(&qid) {
+                                    let _ = tx.send(sel);
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     })
@@ -240,6 +313,47 @@ fn render_event(event: &AgentEvent, stats: &StreamStats) {
                 println!("  {} {}", "✗".color(theme::ERROR), "Denied".color(theme::ERROR));
             }
         }
+        AgentEvent::QuestionRequested { question } => {
+            print!("{}", theme::CLEAR_LINE);
+            println!();
+            println!(
+                "  {} {}",
+                "?".color(theme::WARNING).bold(),
+                question.prompt.color(theme::TEXT)
+            );
+            println!(
+                "    {} {}",
+                "[0]".color(theme::SUCCESS),
+                format!("suggested: {}", question.suggested_answer).color(theme::TEXT_DIM)
+            );
+            for (i, o) in question.options.iter().enumerate() {
+                println!(
+                    "    {} {} — {}",
+                    format!("[{}]", i + 1).color(theme::TOOL_BG),
+                    o.id.color(theme::TEXT_DIM),
+                    o.label.color(theme::TEXT)
+                );
+            }
+            if question.allow_custom {
+                println!(
+                    "    {}",
+                    "[c] custom text".color(theme::TEXT_DIM)
+                );
+            }
+            println!();
+        }
+        AgentEvent::QuestionResolved {
+            question_id,
+            selection,
+        } => {
+            print!("{}", theme::CLEAR_LINE);
+            println!(
+                "  {} question {} answered: {:?}",
+                "✓".color(theme::SUCCESS),
+                question_id.color(theme::TEXT_DIM),
+                selection
+            );
+        }
         AgentEvent::CostUpdated { input_tokens, output_tokens, estimated_cost_usd } => {
             stats.update_cost(*input_tokens, *output_tokens, (*estimated_cost_usd * 100.0) as u64);
         }
@@ -296,4 +410,28 @@ fn render_event(event: &AgentEvent, stats: &StreamStats) {
 pub fn render_human_event(event: &AgentEvent) {
     let stats = StreamStats::new();
     render_event(event, &stats);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nca_common::event::{InteractiveQuestionPayload, QuestionOption};
+
+    #[test]
+    fn render_question_requested_does_not_panic() {
+        let ev = AgentEvent::QuestionRequested {
+            question: InteractiveQuestionPayload {
+                question_id: "q-1".into(),
+                call_id: "c".into(),
+                prompt: "Test?".into(),
+                options: vec![QuestionOption {
+                    id: "x".into(),
+                    label: "X".into(),
+                }],
+                allow_custom: true,
+                suggested_answer: "X".into(),
+            },
+        };
+        render_human_event(&ev);
+    }
 }

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -2,6 +2,7 @@
 
 use crate::slash_commands::SLASH_COMMANDS;
 use crate::tui::state::{DisplayBlock, TuiSessionState};
+use nca_common::event::QuestionSelection;
 use crossterm::{
     cursor::{Hide, MoveToColumn, Show},
     event::{
@@ -27,9 +28,14 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedSender;
 
+/// Per flattened transcript line: click selects this answer (same indices as `transcript_lines`).
+type LineAnswerHit = Option<QuestionSelection>;
+
 #[derive(Debug)]
 pub enum TuiCmd {
     Submit(String),
+    /// Answer for the current `ask_question` (from question mode or `/auto-answer`).
+    QuestionAnswer(nca_common::event::QuestionSelection),
     CycleAgent,
     CancelTurn,
     Exit,
@@ -136,52 +142,84 @@ pub fn restore_terminal() {
     let _ = disable_raw_mode();
 }
 
-/// Build scrollable transcript lines (for layout + scroll).
-fn transcript_lines(state: &TuiSessionState, width: u16) -> Vec<Line<'static>> {
+#[inline]
+fn push_transcript_line(
+    lines: &mut Vec<Line<'static>>,
+    hits: &mut Vec<LineAnswerHit>,
+    line: Line<'static>,
+    hit: LineAnswerHit,
+) {
+    lines.push(line);
+    hits.push(hit);
+}
+
+/// Build scrollable transcript lines + optional mouse/click targets per line.
+fn transcript_lines_and_hits(state: &TuiSessionState, width: u16) -> (Vec<Line<'static>>, Vec<LineAnswerHit>) {
     let w = width.max(20) as usize;
     let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut hits: Vec<LineAnswerHit> = Vec::new();
 
     for block in &state.blocks {
         match block {
             DisplayBlock::User(content) => {
-                lines.push(Line::from(vec![Span::styled(
-                    " YOU ",
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(theme::USER)
-                        .add_modifier(Modifier::BOLD),
-                )]));
-                lines.push(Line::default());
+                push_transcript_line(
+                    &mut lines,
+                    &mut hits,
+                    Line::from(vec![Span::styled(
+                        " YOU ",
+                        Style::default()
+                            .fg(Color::Black)
+                            .bg(theme::USER)
+                            .add_modifier(Modifier::BOLD),
+                    )]),
+                    None,
+                );
+                push_transcript_line(&mut lines, &mut hits, Line::default(), None);
                 for text_line in wrap_text(content, w) {
-                    lines.push(Line::from(Span::styled(text_line, Style::default().fg(theme::TEXT))));
+                    push_transcript_line(
+                        &mut lines,
+                        &mut hits,
+                        Line::from(Span::styled(text_line, Style::default().fg(theme::TEXT))),
+                        None,
+                    );
                 }
-                lines.push(Line::default());
+                push_transcript_line(&mut lines, &mut hits, Line::default(), None);
             }
             DisplayBlock::Assistant(content) => {
-                lines.push(Line::from(vec![Span::styled(
-                    " nca ",
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(theme::ASSISTANT)
-                        .add_modifier(Modifier::BOLD),
-                )]));
-                lines.push(Line::default());
+                push_transcript_line(
+                    &mut lines,
+                    &mut hits,
+                    Line::from(vec![Span::styled(
+                        " nca ",
+                        Style::default()
+                            .fg(Color::Black)
+                            .bg(theme::ASSISTANT)
+                            .add_modifier(Modifier::BOLD),
+                    )]),
+                    None,
+                );
+                push_transcript_line(&mut lines, &mut hits, Line::default(), None);
                 for text_line in wrap_text(content, w) {
-                    lines.push(parse_md_line(&text_line));
+                    push_transcript_line(&mut lines, &mut hits, parse_md_line(&text_line), None);
                 }
-                lines.push(Line::default());
+                push_transcript_line(&mut lines, &mut hits, Line::default(), None);
             }
             DisplayBlock::ToolRunning { name, .. } => {
-                lines.push(Line::from(vec![
-                    Span::styled(" ⚡ ", Style::default().fg(theme::TOOL)),
-                    Span::styled(
-                        format!("{name} "),
-                        Style::default()
-                            .fg(theme::TOOL)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled("…", Style::default().fg(theme::MUTED)),
-                ]));
+                push_transcript_line(
+                    &mut lines,
+                    &mut hits,
+                    Line::from(vec![
+                        Span::styled(" ⚡ ", Style::default().fg(theme::TOOL)),
+                        Span::styled(
+                            format!("{name} "),
+                            Style::default()
+                                .fg(theme::TOOL)
+                                .add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled("…", Style::default().fg(theme::MUTED)),
+                    ]),
+                    None,
+                );
             }
             DisplayBlock::ToolDone { name, ok, detail } => {
                 let (icon, st) = if *ok {
@@ -189,59 +227,165 @@ fn transcript_lines(state: &TuiSessionState, width: u16) -> Vec<Line<'static>> {
                 } else {
                     ("✗", Style::default().fg(theme::ERROR))
                 };
-                lines.push(Line::from(vec![
-                    Span::styled(format!(" {icon} "), st),
-                    Span::styled(
-                        format!("{name}"),
-                        Style::default().fg(theme::TOOL).add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        format!(" — {}", truncate_chars(detail, 100)),
-                        Style::default().fg(theme::MUTED),
-                    ),
-                ]));
+                push_transcript_line(
+                    &mut lines,
+                    &mut hits,
+                    Line::from(vec![
+                        Span::styled(format!(" {icon} "), st),
+                        Span::styled(
+                            format!("{name}"),
+                            Style::default().fg(theme::TOOL).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(
+                            format!(" — {}", truncate_chars(detail, 100)),
+                            Style::default().fg(theme::MUTED),
+                        ),
+                    ]),
+                    None,
+                );
             }
             DisplayBlock::System(s) => {
-                lines.push(Line::from(Span::styled(
-                    format!(" ‣ {s}"),
-                    Style::default().fg(theme::WARN),
-                )));
+                push_transcript_line(
+                    &mut lines,
+                    &mut hits,
+                    Line::from(Span::styled(
+                        format!(" ‣ {s}"),
+                        Style::default().fg(theme::WARN),
+                    )),
+                    None,
+                );
+            }
+            DisplayBlock::Question(q) => {
+                push_transcript_line(
+                    &mut lines,
+                    &mut hits,
+                    Line::from(vec![
+                        Span::styled(" ? ", Style::default().fg(Color::Black).bg(theme::WARN).bold()),
+                        Span::styled(
+                            " question ",
+                            Style::default().fg(theme::WARN).add_modifier(Modifier::BOLD),
+                        ),
+                    ]),
+                    None,
+                );
+                push_transcript_line(&mut lines, &mut hits, Line::default(), None);
+                for text_line in wrap_text(&q.prompt, w) {
+                    push_transcript_line(
+                        &mut lines,
+                        &mut hits,
+                        Line::from(Span::styled(text_line, Style::default().fg(theme::TEXT))),
+                        None,
+                    );
+                }
+                push_transcript_line(
+                    &mut lines,
+                    &mut hits,
+                    Line::from(vec![
+                        Span::styled(
+                            format!("  [0] suggested: {} ", q.suggested_answer),
+                            Style::default().fg(theme::SUCCESS).add_modifier(Modifier::UNDERLINED),
+                        ),
+                        Span::styled("(click)", Style::default().fg(theme::MUTED)),
+                    ]),
+                    Some(QuestionSelection::Suggested),
+                );
+                for (i, o) in q.options.iter().enumerate() {
+                    push_transcript_line(
+                        &mut lines,
+                        &mut hits,
+                        Line::from(vec![
+                            Span::styled(
+                                format!("  [{}] ({}) {} ", i + 1, o.id, o.label),
+                                Style::default().fg(theme::TEXT).add_modifier(Modifier::UNDERLINED),
+                            ),
+                            Span::styled("(click)", Style::default().fg(theme::MUTED)),
+                        ]),
+                        Some(QuestionSelection::Option {
+                            option_id: o.id.clone(),
+                        }),
+                    );
+                }
+                if q.allow_custom {
+                    push_transcript_line(
+                        &mut lines,
+                        &mut hits,
+                        Line::from(Span::styled(
+                            "  [c] type your own answer below, then Enter",
+                            Style::default().fg(theme::MUTED),
+                        )),
+                        None,
+                    );
+                }
+                push_transcript_line(
+                    &mut lines,
+                    &mut hits,
+                    Line::from(Span::styled(
+                        "  Tip: /auto-answer or Enter on empty = suggested · click an option above",
+                        Style::default().fg(theme::MUTED),
+                    )),
+                    None,
+                );
+                push_transcript_line(&mut lines, &mut hits, Line::default(), None);
             }
             DisplayBlock::ErrorLine(s) => {
-                lines.push(Line::from(Span::styled(
-                    format!(" ✗ {s}"),
-                    Style::default().fg(theme::ERROR),
-                )));
+                push_transcript_line(
+                    &mut lines,
+                    &mut hits,
+                    Line::from(Span::styled(
+                        format!(" ✗ {s}"),
+                        Style::default().fg(theme::ERROR),
+                    )),
+                    None,
+                );
             }
         }
     }
 
     if let Some(stream) = &state.streaming_assistant {
         if !stream.is_empty() {
-            lines.push(Line::from(vec![
-                Span::styled(" nca ", Style::default().fg(Color::Black).bg(theme::ASSISTANT)),
-                Span::styled(" streaming", Style::default().fg(theme::MUTED)),
-            ]));
-            lines.push(Line::default());
+            push_transcript_line(
+                &mut lines,
+                &mut hits,
+                Line::from(vec![
+                    Span::styled(" nca ", Style::default().fg(Color::Black).bg(theme::ASSISTANT)),
+                    Span::styled(" streaming", Style::default().fg(theme::MUTED)),
+                ]),
+                None,
+            );
+            push_transcript_line(&mut lines, &mut hits, Line::default(), None);
             for text_line in wrap_text(stream, w) {
-                lines.push(parse_md_line(&text_line));
+                push_transcript_line(&mut lines, &mut hits, parse_md_line(&text_line), None);
             }
         }
     }
 
     if lines.is_empty() {
-        lines.push(Line::from(vec![
-            Span::styled("nca", Style::default().fg(theme::ASSISTANT).add_modifier(Modifier::BOLD)),
-            Span::styled(" — session ready", Style::default().fg(theme::MUTED)),
-        ]));
-        lines.push(Line::default());
-        lines.push(Line::from(Span::styled(
-            "Tab  agent   !cmd  shell   @path  search   /  commands   wheel  scroll",
-            Style::default().fg(theme::MUTED),
-        )));
+        push_transcript_line(
+            &mut lines,
+            &mut hits,
+            Line::from(vec![
+                Span::styled("nca", Style::default().fg(theme::ASSISTANT).add_modifier(Modifier::BOLD)),
+                Span::styled(" — session ready", Style::default().fg(theme::MUTED)),
+            ]),
+            None,
+        );
+        push_transcript_line(&mut lines, &mut hits, Line::default(), None);
+        push_transcript_line(
+            &mut lines,
+            &mut hits,
+            Line::from(Span::styled(
+                "Tab  agent   !cmd  shell   @path  search   /  commands   wheel  scroll",
+                Style::default().fg(theme::MUTED),
+            )),
+            None,
+        );
     }
 
-    lines
+    (lines, hits)
+}
+
+fn transcript_lines(state: &TuiSessionState, width: u16) -> Vec<Line<'static>> {
+    transcript_lines_and_hits(state, width).0
 }
 
 fn truncate_chars(s: &str, max: usize) -> String {
@@ -322,9 +466,35 @@ fn parse_md_line(line: &str) -> Line<'static> {
     Line::from(spans)
 }
 
+fn parse_tui_question_answer(
+    raw: &str,
+    q: &nca_common::event::InteractiveQuestionPayload,
+) -> Option<QuestionSelection> {
+    let t = raw.trim();
+    if t.is_empty() || t == "0" || t.eq_ignore_ascii_case("s") {
+        return Some(QuestionSelection::Suggested);
+    }
+    if let Ok(n) = t.parse::<usize>() {
+        if n >= 1 && n <= q.options.len() {
+            return Some(QuestionSelection::Option {
+                option_id: q.options[n - 1].id.clone(),
+            });
+        }
+    }
+    if q.allow_custom && !t.is_empty() {
+        return Some(QuestionSelection::Custom {
+            text: t.to_string(),
+        });
+    }
+    None
+}
+
+/// `question_answer_tx`: when `Some`, answers are sent there so they unblock `ask_question` while
+/// the async loop is stuck in `run_turn` (that task does not poll `cmd_rx` until the turn ends).
 pub fn run_blocking(
     state: Arc<Mutex<TuiSessionState>>,
     cmd_tx: UnboundedSender<TuiCmd>,
+    question_answer_tx: Option<UnboundedSender<(String, QuestionSelection)>>,
     show_run_banner: bool,
 ) -> anyhow::Result<()> {
     let mut terminal = setup_terminal()?;
@@ -352,10 +522,15 @@ pub fn run_blocking(
                 let (tr, st_r, slash_opt, inp_r) = layout_chunks(area, slash_h);
 
                 let transcript_h = tr.height.saturating_sub(2) as usize;
-                let lines = transcript_lines(&g, tr.width.saturating_sub(2));
+                let inner_w = tr.width.saturating_sub(2);
+                let (lines, _hits) = transcript_lines_and_hits(&g, inner_w);
                 let total = lines.len();
                 let max_scroll = total.saturating_sub(transcript_h);
-                g.scroll_lines = g.scroll_lines.min(max_scroll);
+                if g.transcript_follow_tail {
+                    g.scroll_lines = max_scroll;
+                } else {
+                    g.scroll_lines = g.scroll_lines.min(max_scroll);
+                }
                 let start = g.scroll_lines;
                 let end = (start + transcript_h).min(total);
                 let visible: Vec<Line> = if start < end {
@@ -365,7 +540,7 @@ pub fn run_blocking(
                 };
 
                 let title = format!(
-                    " transcript — {} lines (↑↓ wheel) ",
+                    " transcript — {} lines (↑↓ wheel · End bottom) ",
                     total
                 );
                 let main = Paragraph::new(Text::from(visible))
@@ -386,8 +561,14 @@ pub fn run_blocking(
                 } else {
                     Span::styled(" ○ idle ", Style::default().fg(theme::SUCCESS))
                 };
+                let q_hint = if g.active_question.is_some() {
+                    Span::styled(" ?answer ", Style::default().fg(theme::WARN))
+                } else {
+                    Span::raw("")
+                };
                 let status = Line::from(vec![
                     busy,
+                    q_hint,
                     Span::raw(" │ "),
                     Span::styled(&g.model, Style::default().fg(theme::USER)),
                     Span::raw(" │ "),
@@ -483,7 +664,12 @@ pub fn run_blocking(
                     ),
                 ]);
 
-                let hint = if g.input_buffer.is_empty() {
+                let hint = if g.active_question.is_some() {
+                    Line::from(Span::styled(
+                        "Enter / 0 = suggested · 1–n = option · click underlined line · /auto-answer · End = transcript bottom (empty input)",
+                        Style::default().fg(theme::WARN),
+                    ))
+                } else if g.input_buffer.is_empty() {
                     Line::from(Span::styled(
                         "Enter send · Tab agent · / for commands · Esc exit · Ctrl+L clear",
                         Style::default().fg(theme::MUTED),
@@ -492,12 +678,17 @@ pub fn run_blocking(
                     Line::default()
                 };
 
+                let input_title = if g.active_question.is_some() {
+                    " answer "
+                } else {
+                    " message "
+                };
                 let input_block = Paragraph::new(Text::from(vec![input_line, hint]))
                     .block(
                         Block::default()
                             .borders(Borders::ALL)
                             .border_style(Style::default().fg(theme::BORDER))
-                            .title(Span::styled(" message ", Style::default().fg(theme::MUTED))),
+                            .title(Span::styled(input_title, Style::default().fg(theme::MUTED))),
                     )
                     .style(Style::default().bg(theme::SURFACE));
 
@@ -518,17 +709,50 @@ pub fn run_blocking(
                     let (tr, _, slash_r, _) = layout_chunks(area, sh);
 
                     if rect_contains(tr, m.column, m.row) {
-                        let lines = transcript_lines(&g, tr.width.saturating_sub(2));
+                        let inner_w = tr.width.saturating_sub(2);
+                        let (lines, hits) = transcript_lines_and_hits(&g, inner_w);
                         let total = lines.len();
                         let th = tr.height.saturating_sub(2) as usize;
                         let max_scroll = total.saturating_sub(th);
                         match m.kind {
                             MouseEventKind::ScrollUp => {
+                                g.transcript_follow_tail = false;
                                 g.scroll_lines = g.scroll_lines.saturating_sub(MOUSE_SCROLL_LINES);
                             }
                             MouseEventKind::ScrollDown => {
                                 g.scroll_lines =
                                     (g.scroll_lines + MOUSE_SCROLL_LINES).min(max_scroll);
+                                if g.scroll_lines >= max_scroll {
+                                    g.transcript_follow_tail = true;
+                                }
+                            }
+                            MouseEventKind::Down(MouseButton::Left) => {
+                                // Inner content starts below top border (y+1).
+                                let inner_top = tr.y.saturating_add(1);
+                                if m.row >= inner_top {
+                                    let row_in_area = (m.row - inner_top) as usize;
+                                    if row_in_area < th {
+                                        let gline = g.scroll_lines + row_in_area;
+                                        let picked = if gline < hits.len() {
+                                            hits[gline].clone().zip(
+                                                g.active_question
+                                                    .as_ref()
+                                                    .map(|q| q.question_id.clone()),
+                                            )
+                                        } else {
+                                            None
+                                        };
+                                        if let Some((sel, qid)) = picked {
+                                            drop(g);
+                                            if let Some(ref tx) = question_answer_tx {
+                                                let _ = tx.send((qid, sel));
+                                            } else {
+                                                let _ = cmd_tx.send(TuiCmd::QuestionAnswer(sel));
+                                            }
+                                            continue;
+                                        }
+                                    }
+                                }
                             }
                             _ => {}
                         }
@@ -566,6 +790,7 @@ pub fn run_blocking(
                         g.blocks.clear();
                         g.streaming_assistant = None;
                         g.scroll_lines = 0;
+                        g.transcript_follow_tail = true;
                     }
                     (KeyCode::Tab, _) => {
                         let filtered = filter_slash_commands(&g.input_buffer);
@@ -582,14 +807,70 @@ pub fn run_blocking(
                         let line = std::mem::take(&mut g.input_buffer);
                         g.cursor_char_idx = 0;
                         g.slash_menu_index = 0;
+                        let active_q = g.active_question.clone();
+                        if let Some(ref q) = active_q {
+                            let t = line.trim();
+                            // `/auto-answer` must go through the side channel: `run_turn` is often
+                            // blocked on this question, so `cmd_rx` is not polled for Submit.
+                            if t == "/auto-answer" {
+                                let qid = q.question_id.clone();
+                                drop(g);
+                                if let Some(ref tx) = question_answer_tx {
+                                    let _ = tx.send((qid, QuestionSelection::Suggested));
+                                } else {
+                                    let _ = cmd_tx.send(TuiCmd::QuestionAnswer(
+                                        QuestionSelection::Suggested,
+                                    ));
+                                }
+                                continue;
+                            }
+                            if t.starts_with('/') {
+                                drop(g);
+                                let _ = cmd_tx.send(TuiCmd::Submit(line));
+                                continue;
+                            }
+                            if let Some(sel) = parse_tui_question_answer(&line, q) {
+                                let qid = q.question_id.clone();
+                                drop(g);
+                                if let Some(ref tx) = question_answer_tx {
+                                    let _ = tx.send((qid, sel));
+                                } else {
+                                    let _ = cmd_tx.send(TuiCmd::QuestionAnswer(sel));
+                                }
+                                continue;
+                            }
+                            g.blocks.push(DisplayBlock::System(
+                                "Invalid answer: use Enter/0 for suggested, 1–n for an option, or custom text."
+                                    .into(),
+                            ));
+                            continue;
+                        }
                         drop(g);
                         let _ = cmd_tx.send(TuiCmd::Submit(line));
                     }
                     (KeyCode::Char('a'), KeyModifiers::CONTROL) | (KeyCode::Home, _) => {
                         g.cursor_char_idx = 0;
                     }
-                    (KeyCode::Char('e'), KeyModifiers::CONTROL) | (KeyCode::End, _) => {
+                    (KeyCode::Char('e'), KeyModifiers::CONTROL) => {
                         g.cursor_char_idx = g.input_buffer.chars().count();
+                    }
+                    (KeyCode::End, _) => {
+                        if !g.input_buffer.is_empty() {
+                            g.cursor_char_idx = g.input_buffer.chars().count();
+                        } else {
+                            let sz = terminal.size().ok();
+                            if let Some(sz) = sz {
+                                let area = Rect::new(0, 0, sz.width, sz.height);
+                                let sh =
+                                    slash_panel_height(filter_slash_commands(&g.input_buffer).len());
+                                let (tr, _, _, _) = layout_chunks(area, sh);
+                                let total = transcript_lines(&g, tr.width.saturating_sub(2)).len();
+                                let th = tr.height.saturating_sub(2) as usize;
+                                let max_scroll = total.saturating_sub(th);
+                                g.transcript_follow_tail = true;
+                                g.scroll_lines = max_scroll;
+                            }
+                        }
                     }
                     (KeyCode::Left, _) => {
                         g.cursor_char_idx = g.cursor_char_idx.saturating_sub(1);
@@ -603,6 +884,7 @@ pub fn run_blocking(
                         if !filtered.is_empty() && slash_panel_visible(&g.input_buffer) {
                             g.slash_menu_index = g.slash_menu_index.saturating_sub(1);
                         } else {
+                            g.transcript_follow_tail = false;
                             g.scroll_lines = g.scroll_lines.saturating_sub(1);
                         }
                     }
@@ -622,6 +904,9 @@ pub fn run_blocking(
                                 let th = tr.height.saturating_sub(2) as usize;
                                 let max_scroll = total.saturating_sub(th);
                                 g.scroll_lines = (g.scroll_lines + 1).min(max_scroll);
+                                if g.scroll_lines >= max_scroll {
+                                    g.transcript_follow_tail = true;
+                                }
                             }
                         }
                     }

--- a/crates/cli/src/tui/bridge.rs
+++ b/crates/cli/src/tui/bridge.rs
@@ -1,7 +1,7 @@
 //! Event fanout: session log, IPC, and TUI state (no stdout streaming).
 
 use crate::tui::state::TuiSessionState;
-use nca_common::event::{AgentEvent, EventEnvelope};
+use nca_common::event::{AgentEvent, EventEnvelope, QuestionSelection};
 use nca_runtime::ipc::IpcHandle;
 use nca_runtime::supervisor;
 use std::collections::HashMap;
@@ -19,6 +19,7 @@ pub fn spawn_tui_bridge(
     log_path: std::path::PathBuf,
     ipc_handle: Option<IpcHandle>,
     approval_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>>,
+    question_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>>,
     state: Arc<Mutex<TuiSessionState>>,
 ) -> tokio::task::JoinHandle<()> {
     let (event_tx_ipc, command_rx) = match ipc_handle {
@@ -30,7 +31,7 @@ pub fn spawn_tui_bridge(
     };
 
     if let Some(crx) = command_rx {
-        supervisor::spawn_command_consumer(crx, approval_pending, None);
+        supervisor::spawn_command_consumer(crx, approval_pending, question_pending, None);
     }
 
     let ipc = event_tx_ipc.map(|tx| IpcFanout { tx });

--- a/crates/cli/src/tui/state.rs
+++ b/crates/cli/src/tui/state.rs
@@ -1,6 +1,6 @@
 //! Transcript + status driven by `AgentEvent`.
 
-use nca_common::event::AgentEvent;
+use nca_common::event::{AgentEvent, InteractiveQuestionPayload};
 use std::time::Instant;
 
 #[derive(Debug, Clone)]
@@ -13,6 +13,8 @@ pub enum DisplayBlock {
         ok: bool,
         detail: String,
     },
+    /// Interactive `ask_question` prompt (options + suggested answer).
+    Question(InteractiveQuestionPayload),
     System(String),
     ErrorLine(String),
 }
@@ -25,6 +27,8 @@ pub struct TuiSessionState {
     pub cursor_char_idx: usize,
     /// Scroll offset in *lines* (flattened transcript).
     pub scroll_lines: usize,
+    /// When true, transcript stays pinned to the bottom as new output arrives.
+    pub transcript_follow_tail: bool,
     pub session_id: String,
     pub model: String,
     pub agent_profile: String,
@@ -37,6 +41,8 @@ pub struct TuiSessionState {
     pub should_exit: bool,
     /// Selected row in slash-command popup (↑↓ or click).
     pub slash_menu_index: usize,
+    /// When set, the composer answers this question (see status hint).
+    pub active_question: Option<InteractiveQuestionPayload>,
 }
 
 impl TuiSessionState {
@@ -52,6 +58,7 @@ impl TuiSessionState {
             input_buffer: String::new(),
             cursor_char_idx: 0,
             scroll_lines: 0,
+            transcript_follow_tail: true,
             session_id,
             model,
             agent_profile,
@@ -63,6 +70,7 @@ impl TuiSessionState {
             busy: false,
             should_exit: false,
             slash_menu_index: 0,
+            active_question: None,
         }
     }
 
@@ -167,6 +175,21 @@ impl TuiSessionState {
                 };
                 self.blocks.push(DisplayBlock::System(line));
             }
+            AgentEvent::QuestionRequested { question } => {
+                self.active_question = Some(question.clone());
+                self.blocks.push(DisplayBlock::Question(question.clone()));
+                // Bring the prompt into view when follow-tail is on (default).
+                self.transcript_follow_tail = true;
+            }
+            AgentEvent::QuestionResolved {
+                question_id,
+                selection,
+            } => {
+                self.active_question = None;
+                self.blocks.push(DisplayBlock::System(format!(
+                    "Answered question {question_id}: {selection:?}"
+                )));
+            }
             AgentEvent::CostUpdated {
                 input_tokens,
                 output_tokens,
@@ -220,5 +243,43 @@ fn truncate(s: &str, max: usize) -> String {
         t.to_string()
     } else {
         format!("{}…", t.chars().take(max.saturating_sub(1)).collect::<String>())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nca_common::event::{InteractiveQuestionPayload, QuestionOption, QuestionSelection};
+
+    #[test]
+    fn question_requested_sets_active_question() {
+        let mut st = TuiSessionState::new(
+            "session-x".into(),
+            "m".into(),
+            "@build".into(),
+            "default".into(),
+        );
+        let q = InteractiveQuestionPayload {
+            question_id: "q-1".into(),
+            call_id: "c1".into(),
+            prompt: "Pick".into(),
+            options: vec![QuestionOption {
+                id: "a".into(),
+                label: "A".into(),
+            }],
+            allow_custom: true,
+            suggested_answer: "A".into(),
+        };
+        st.apply_event(&AgentEvent::QuestionRequested {
+            question: q.clone(),
+        });
+        assert_eq!(st.active_question.as_ref().map(|x| x.question_id.as_str()), Some("q-1"));
+        assert!(matches!(st.blocks.last(), Some(DisplayBlock::Question(_))));
+
+        st.apply_event(&AgentEvent::QuestionResolved {
+            question_id: "q-1".into(),
+            selection: QuestionSelection::Suggested,
+        });
+        assert!(st.active_question.is_none());
     }
 }

--- a/crates/common/src/event.rs
+++ b/crates/common/src/event.rs
@@ -89,6 +89,49 @@ pub enum AgentEvent {
         child_session_id: String,
         status: String,
     },
+    /// User must pick an option, use the suggested answer, or enter custom text.
+    /// Emitted when the `ask_question` tool runs; answer via `AgentCommand::AnswerQuestion` or local CLI.
+    QuestionRequested {
+        question: InteractiveQuestionPayload,
+    },
+    /// Logged after the user (or orchestrator) answers a question.
+    QuestionResolved {
+        question_id: String,
+        selection: QuestionSelection,
+    },
+}
+
+/// One selectable row shown for an interactive question.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QuestionOption {
+    pub id: String,
+    pub label: String,
+}
+
+/// Full question payload broadcast on the event bus and shown in the CLI.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InteractiveQuestionPayload {
+    pub question_id: String,
+    pub call_id: String,
+    pub prompt: String,
+    pub options: Vec<QuestionOption>,
+    #[serde(default = "default_allow_custom")]
+    pub allow_custom: bool,
+    /// Model-provided default; user can accept via suggested / `/auto-answer`.
+    pub suggested_answer: String,
+}
+
+fn default_allow_custom() -> bool {
+    true
+}
+
+/// How the user answered an interactive question.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum QuestionSelection {
+    Option { option_id: String },
+    Custom { text: String },
+    Suggested,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -112,6 +155,11 @@ pub enum AgentCommand {
     DenyToolCall {
         call_id: String,
     },
+    /// Submit an answer for the pending `ask_question` with matching `question_id`.
+    AnswerQuestion {
+        question_id: String,
+        selection: QuestionSelection,
+    },
     Cancel,
     Shutdown,
 }
@@ -130,4 +178,57 @@ pub enum AgentResponse {
         message: String,
     },
     Ok,
+}
+
+#[cfg(test)]
+mod interactive_question_serde_tests {
+    use super::*;
+
+    #[test]
+    fn question_requested_roundtrip() {
+        let q = InteractiveQuestionPayload {
+            question_id: "q-1".into(),
+            call_id: "call_1".into(),
+            prompt: "Pick one".into(),
+            options: vec![
+                QuestionOption {
+                    id: "a".into(),
+                    label: "Alpha".into(),
+                },
+                QuestionOption {
+                    id: "b".into(),
+                    label: "Beta".into(),
+                },
+            ],
+            allow_custom: true,
+            suggested_answer: "Alpha".into(),
+        };
+        let ev = AgentEvent::QuestionRequested { question: q.clone() };
+        let json = serde_json::to_string(&ev).expect("serialize");
+        let back: AgentEvent = serde_json::from_str(&json).expect("deserialize");
+        match back {
+            AgentEvent::QuestionRequested { question } => assert_eq!(question, q),
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn answer_question_command_roundtrip() {
+        let cmd = AgentCommand::AnswerQuestion {
+            question_id: "q-1".into(),
+            selection: QuestionSelection::Suggested,
+        };
+        let json = serde_json::to_string(&cmd).expect("serialize");
+        let back: AgentCommand = serde_json::from_str(&json).expect("deserialize");
+        match back {
+            AgentCommand::AnswerQuestion {
+                question_id,
+                selection,
+            } => {
+                assert_eq!(question_id, "q-1");
+                assert!(matches!(selection, QuestionSelection::Suggested));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
 }

--- a/crates/core/src/approval.rs
+++ b/crates/core/src/approval.rs
@@ -59,6 +59,7 @@ impl ApprovalPolicy {
                 | "query_symbols"
                 | "web_search"
                 | "fetch_url"
+                | "ask_question"
         );
         let file_edit = matches!(
             tool_name,

--- a/crates/core/src/harness.rs
+++ b/crates/core/src/harness.rs
@@ -38,6 +38,7 @@ Tool and validation rules:
 - If a command or edit could be destructive, expensive, or policy-sensitive, ask for approval or explain why it is needed.
 - Empty provider completions, empty tool results, or obviously invalid outputs must fail loudly instead of being treated as success.
 - Do not pretend a tool, provider, or validation step succeeded if it did not.
+- When you need structured choices from the user (preferences, stack, deploy target, etc.), use the `ask_question` tool with clear `options`, `allow_custom` when freeform is useful, and always set `suggested_answer` to your best recommendation so the user can accept quickly.
 
 Headless and orchestrator rules:
 - Headless runs must behave predictably for external orchestrators.

--- a/crates/core/src/tools/ask_question.rs
+++ b/crates/core/src/tools/ask_question.rs
@@ -1,0 +1,243 @@
+//! Interactive multiple-choice / custom / suggested-answer questions for the user.
+
+use nca_common::event::{
+    AgentEvent, InteractiveQuestionPayload, QuestionOption, QuestionSelection,
+};
+use nca_common::tool::{ToolCall, ToolDefinition, ToolResult};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+use super::ToolExecutor;
+
+const WAIT_SECS: u64 = 3600;
+
+fn selection_summary(sel: &QuestionSelection, payload: &InteractiveQuestionPayload) -> String {
+    match sel {
+        QuestionSelection::Suggested => format!(
+            "Selected suggested answer: {}",
+            payload.suggested_answer
+        ),
+        QuestionSelection::Option { option_id } => {
+            let label = payload
+                .options
+                .iter()
+                .find(|o| o.id == *option_id)
+                .map(|o| o.label.as_str())
+                .unwrap_or(option_id.as_str());
+            format!("Selected option `{option_id}`: {label}")
+        }
+        QuestionSelection::Custom { text } => format!("Custom answer: {text}"),
+    }
+}
+
+/// Tool that blocks until the user answers via CLI or `AgentCommand::AnswerQuestion`.
+pub struct AskQuestionTool {
+    event_tx: mpsc::Sender<AgentEvent>,
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>,
+}
+
+impl AskQuestionTool {
+    pub fn new(
+        event_tx: mpsc::Sender<AgentEvent>,
+        pending: Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>,
+    ) -> Self {
+        Self { event_tx, pending }
+    }
+}
+
+#[async_trait::async_trait]
+impl ToolExecutor for AskQuestionTool {
+    fn definition(&self) -> ToolDefinition {
+        ToolDefinition {
+            name: "ask_question".into(),
+            description: "Ask the user a structured question with multiple choices, an optional \
+                custom text answer, and a suggested default (always provide `suggested_answer`). \
+                The UI shows options and the suggestion; the user can pick one, type custom text, \
+                or accept the suggestion (e.g. `/auto-answer`). Use this instead of long numbered \
+                lists in plain assistant text when you need a fast, reliable answer."
+                .into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "The question text shown to the user."
+                    },
+                    "options": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": { "type": "string", "description": "Stable id for this option (e.g. static_site)." },
+                                "label": { "type": "string", "description": "Human-readable label." }
+                            },
+                            "required": ["id", "label"]
+                        },
+                        "description": "List of choices; each needs a unique id."
+                    },
+                    "allow_custom": {
+                        "type": "boolean",
+                        "description": "If true, user can submit freeform text. Default true."
+                    },
+                    "suggested_answer": {
+                        "type": "string",
+                        "description": "Your best guess / recommendation; always set this so the user can accept quickly."
+                    }
+                },
+                "required": ["prompt", "options", "suggested_answer"]
+            }),
+        }
+    }
+
+    async fn execute(&self, call: &ToolCall) -> ToolResult {
+        let prompt = call.input["prompt"].as_str().unwrap_or("").trim().to_string();
+        if prompt.is_empty() {
+            return ToolResult {
+                call_id: call.id.clone(),
+                success: false,
+                output: String::new(),
+                error: Some("prompt is required".into()),
+            };
+        }
+
+        let suggested = call
+            .input["suggested_answer"]
+            .as_str()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if suggested.is_empty() {
+            return ToolResult {
+                call_id: call.id.clone(),
+                success: false,
+                output: String::new(),
+                error: Some("suggested_answer is required (provide your recommended choice)".into()),
+            };
+        }
+
+        let allow_custom = call
+            .input
+            .get("allow_custom")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
+        let options: Vec<QuestionOption> = match call.input.get("options") {
+            Some(serde_json::Value::Array(arr)) => {
+                let mut out = Vec::new();
+                for v in arr {
+                    let id = v
+                        .get("id")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    let label = v
+                        .get("label")
+                        .and_then(|x| x.as_str())
+                        .unwrap_or("")
+                        .trim()
+                        .to_string();
+                    if id.is_empty() || label.is_empty() {
+                        return ToolResult {
+                            call_id: call.id.clone(),
+                            success: false,
+                            output: String::new(),
+                            error: Some("each option needs non-empty id and label".into()),
+                        };
+                    }
+                    out.push(QuestionOption { id, label });
+                }
+                out
+            }
+            _ => {
+                return ToolResult {
+                    call_id: call.id.clone(),
+                    success: false,
+                    output: String::new(),
+                    error: Some("options must be a non-empty array of {id, label}".into()),
+                };
+            }
+        };
+
+        if options.is_empty() {
+            return ToolResult {
+                call_id: call.id.clone(),
+                success: false,
+                output: String::new(),
+                error: Some("at least one option is required".into()),
+            };
+        }
+
+        let question_id = format!("q-{}", call.id);
+        let payload = InteractiveQuestionPayload {
+            question_id: question_id.clone(),
+            call_id: call.id.clone(),
+            prompt,
+            options,
+            allow_custom,
+            suggested_answer: suggested,
+        };
+
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut m = self.pending.lock().unwrap();
+            m.insert(question_id.clone(), tx);
+        }
+
+        if self
+            .event_tx
+            .send(AgentEvent::QuestionRequested {
+                question: payload.clone(),
+            })
+            .await
+            .is_err()
+        {
+            let mut m = self.pending.lock().unwrap();
+            m.remove(&question_id);
+            return ToolResult {
+                call_id: call.id.clone(),
+                success: false,
+                output: String::new(),
+                error: Some("failed to emit QuestionRequested (session ended?)".into()),
+            };
+        }
+
+        let selection = match tokio::time::timeout(std::time::Duration::from_secs(WAIT_SECS), rx)
+            .await
+        {
+            Ok(Ok(sel)) => sel,
+            Ok(Err(_)) | Err(_) => {
+                let mut m = self.pending.lock().unwrap();
+                m.remove(&question_id);
+                return ToolResult {
+                    call_id: call.id.clone(),
+                    success: false,
+                    output: String::new(),
+                    error: Some(
+                        "timed out or channel closed waiting for question answer; use IPC \
+                         AnswerQuestion or an interactive terminal"
+                            .into(),
+                    ),
+                };
+            }
+        };
+
+        let summary = selection_summary(&selection, &payload);
+        let _ = self
+            .event_tx
+            .send(AgentEvent::QuestionResolved {
+                question_id: question_id.clone(),
+                selection: selection.clone(),
+            })
+            .await;
+
+        ToolResult {
+            call_id: call.id.clone(),
+            success: true,
+            output: summary,
+            error: None,
+        }
+    }
+}

--- a/crates/core/src/tools/mod.rs
+++ b/crates/core/src/tools/mod.rs
@@ -1,4 +1,5 @@
 pub mod apply_patch;
+pub mod ask_question;
 pub mod bash;
 pub mod code_intel_tool;
 pub mod copy_path;
@@ -18,6 +19,8 @@ pub mod spawn_subagent;
 pub mod types;
 pub mod web_search;
 pub mod write_file;
+
+pub use ask_question::AskQuestionTool;
 
 use nca_common::config::WebConfig;
 use nca_common::tool::{ToolCall, ToolDefinition, ToolResult};

--- a/crates/runtime/src/service.rs
+++ b/crates/runtime/src/service.rs
@@ -131,6 +131,7 @@ async fn run_service_session_with_startup(
         .take_event_rx()
         .ok_or_else(|| "missing event receiver".to_string())?;
     let approval_pending = handle.take_approval_pending();
+    let question_pending = handle.take_question_pending();
 
     let mut command_rx = None;
     let mut event_tx_ipc = None;
@@ -164,6 +165,7 @@ async fn run_service_session_with_startup(
         spawn_command_consumer_with_store(
             crx,
             approval_pending,
+            question_pending.clone(),
             None,
             supervisor.event_tx(),
             Some(prompt_tx.clone()),

--- a/crates/runtime/src/supervisor.rs
+++ b/crates/runtime/src/supervisor.rs
@@ -4,7 +4,7 @@ use crate::pty::PtyManager;
 use crate::session_store::SessionStore;
 use chrono::Utc;
 use nca_common::config::NcaConfig;
-use nca_common::event::{AgentCommand, AgentEvent, EndReason, EventEnvelope};
+use nca_common::event::{AgentCommand, AgentEvent, EndReason, EventEnvelope, QuestionSelection};
 use nca_common::session::{
     OrchestrationContext, SessionMeta, SessionSnapshot, SessionState, SessionStatus,
 };
@@ -17,6 +17,7 @@ use nca_core::provider::factory::build_provider;
 use nca_core::tools::ToolRegistry;
 use nca_core::tools::mcp::load_mcp_tools;
 use nca_core::tools::spawn_subagent::{SpawnRequest, SpawnSubagentTool};
+use nca_core::tools::AskQuestionTool;
 use serde_json::json;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -41,6 +42,7 @@ pub struct Supervisor {
     ipc_handle: Option<IpcHandle>,
     event_rx: Option<mpsc::Receiver<AgentEvent>>,
     approval_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>>,
+    question_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>>,
     spawn_rx: Option<mpsc::Receiver<SpawnRequest>>,
     worktree_path: Option<PathBuf>,
     branch: Option<String>,
@@ -78,6 +80,7 @@ pub struct SupervisorHandle {
     event_rx: Option<mpsc::Receiver<AgentEvent>>,
     ipc_handle: Option<IpcHandle>,
     approval_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>>,
+    question_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>>,
     spawn_rx: Option<mpsc::Receiver<SpawnRequest>>,
 }
 
@@ -94,6 +97,12 @@ impl SupervisorHandle {
         &mut self,
     ) -> Option<Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>> {
         self.approval_pending.take()
+    }
+
+    pub fn take_question_pending(
+        &mut self,
+    ) -> Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>> {
+        self.question_pending.take()
     }
 
     pub fn take_spawn_rx(&mut self) -> Option<mpsc::Receiver<SpawnRequest>> {
@@ -162,6 +171,12 @@ impl Supervisor {
         };
 
         let (event_tx, event_rx) = mpsc::channel(256);
+        let question_pending = Arc::new(Mutex::new(HashMap::new()));
+        tools.register(Box::new(AskQuestionTool::new(
+            event_tx.clone(),
+            question_pending.clone(),
+        )));
+
         let session_id = cfg.session_id.unwrap_or_else(generate_session_id);
         let session_store = SessionStore::new(workspace_root.join(&config.session.history_dir));
 
@@ -188,7 +203,7 @@ impl Supervisor {
             tools,
             approval,
             config.model.default_model.clone(),
-            event_tx,
+            event_tx.clone(),
             config.session.max_turns_per_run,
             config.session.max_tool_calls_per_turn,
             config.session.checkpoint_interval,
@@ -211,6 +226,7 @@ impl Supervisor {
             ipc_handle: Some(ipc_handle),
             event_rx: Some(event_rx),
             approval_pending,
+            question_pending: Some(question_pending),
             spawn_rx: Some(spawn_rx),
             worktree_path: None,
             branch: None,
@@ -289,6 +305,7 @@ impl Supervisor {
             event_rx: self.event_rx.take(),
             ipc_handle: self.ipc_handle.take(),
             approval_pending: self.approval_pending.take(),
+            question_pending: self.question_pending.take(),
             spawn_rx: self.spawn_rx.take(),
         }
     }
@@ -537,11 +554,13 @@ pub fn spawn_event_fanout(
 pub fn spawn_command_consumer(
     command_rx: mpsc::UnboundedReceiver<AgentCommand>,
     approval_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>>,
+    question_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>>,
     cancel_tx: Option<oneshot::Sender<()>>,
 ) -> tokio::task::JoinHandle<()> {
     spawn_command_consumer_with_store(
         command_rx,
         approval_pending,
+        question_pending,
         cancel_tx,
         None,
         None,
@@ -559,6 +578,7 @@ pub enum SessionControlCommand {
 pub fn spawn_command_consumer_with_store(
     mut command_rx: mpsc::UnboundedReceiver<AgentCommand>,
     approval_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<bool>>>>>,
+    question_pending: Option<Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>>>,
     cancel_tx: Option<oneshot::Sender<()>>,
     event_tx: Option<mpsc::Sender<AgentEvent>>,
     prompt_tx: Option<mpsc::UnboundedSender<String>>,
@@ -625,6 +645,18 @@ pub fn spawn_command_consumer_with_store(
                                 content,
                             })
                             .await;
+                    }
+                }
+                AgentCommand::AnswerQuestion {
+                    question_id,
+                    selection,
+                } => {
+                    if let Some(ref qp) = question_pending {
+                        if let Ok(mut m) = qp.lock() {
+                            if let Some(tx) = m.remove(&question_id) {
+                                let _ = tx.send(selection);
+                            }
+                        }
                     }
                 }
             }
@@ -1085,6 +1117,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(prompt_tx),
             Some(control_tx),
         );
@@ -1100,6 +1133,43 @@ mod tests {
             .expect("prompt should be forwarded")
             .expect("prompt channel should remain open");
         assert_eq!(received, "hello from ipc");
+
+        let _ = cmd_tx.send(AgentCommand::Shutdown);
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn answer_question_resolves_pending_channel() {
+        use nca_common::event::QuestionSelection;
+
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let pending: Arc<Mutex<HashMap<String, oneshot::Sender<QuestionSelection>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let (tx, rx) = oneshot::channel();
+        pending.lock().unwrap().insert("q-1".into(), tx);
+
+        let task = spawn_command_consumer_with_store(
+            cmd_rx,
+            None,
+            Some(pending.clone()),
+            None,
+            None,
+            None,
+            None,
+        );
+
+        cmd_tx
+            .send(AgentCommand::AnswerQuestion {
+                question_id: "q-1".into(),
+                selection: QuestionSelection::Suggested,
+            })
+            .unwrap();
+
+        let got = tokio::time::timeout(std::time::Duration::from_secs(1), rx)
+            .await
+            .expect("timeout")
+            .expect("channel");
+        assert!(matches!(got, QuestionSelection::Suggested));
 
         let _ = cmd_tx.send(AgentCommand::Shutdown);
         task.abort();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -216,8 +216,12 @@ pub enum AgentEvent {
     Response { response: AgentResponse },
     ChildSessionSpawned { parent_session_id: String, child_session_id: String, task: String, workspace: PathBuf, branch: Option<String> },
     ChildSessionCompleted { parent_session_id: String, child_session_id: String, status: String },
+    QuestionRequested { question: InteractiveQuestionPayload },
+    QuestionResolved { question_id: String, selection: QuestionSelection },
 }
 ```
+
+`InteractiveQuestionPayload` carries `question_id`, `call_id`, `prompt`, `options` (`id` + `label`), `allow_custom`, and `suggested_answer` (always present for fast accept). `QuestionSelection` is an internal tagged enum: `suggested`, `option { option_id }`, or `custom { text }`.
 
 ### Command Schema
 
@@ -226,6 +230,7 @@ pub enum AgentCommand {
     SendMessage { content: String },
     ApproveToolCall { call_id: String },
     DenyToolCall { call_id: String },
+    AnswerQuestion { question_id: String, selection: QuestionSelection },
     Cancel,
     Shutdown,
 }

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -50,11 +50,23 @@ Lifecycle-critical events:
 - `ToolCallCompleted`
 - `ApprovalRequested`
 - `ApprovalResolved`
+- `QuestionRequested` (interactive `ask_question` tool; includes `suggested_answer`)
+- `QuestionResolved`
 - `Checkpoint`
 - `Response`
 - `SessionEnded`
 - `ChildSessionSpawned`
 - `ChildSessionCompleted`
+
+### Answering `QuestionRequested` over IPC
+
+When the model uses the `ask_question` tool, the runtime emits `QuestionRequested` with a `question_id`. Send a newline-delimited JSON command on the session socket:
+
+```json
+{"type":"AnswerQuestion","question_id":"q-<call-id>","selection":{"kind":"suggested"}}
+```
+
+`selection.kind` may be `suggested`, `option` (with `option_id`), or `custom` (with `text`). In the interactive CLI, `/auto-answer` accepts the suggested answer for the active question.
 
 ## Session Snapshot Shape
 


### PR DESCRIPTION
- Introduced the `ask_question` tool to facilitate interactive user prompts with structured options and suggested answers.
- Added `/auto-answer` command in the REPL to automatically accept the model's suggested answer for pending questions.
- Updated the TUI to display interactive questions and handle user responses effectively.
- Enhanced event handling to support question requests and resolutions, improving user interaction during sessions.
- Revised documentation to include new features and usage instructions for the interactive question functionality.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds interactive questions to the CLI/runtime via a new `ask_question` tool. Users can answer in the TUI/REPL, over stdin, or via IPC; `/auto-answer` accepts the model’s suggested answer.

- **New Features**
  - New `ask_question` tool with `prompt`, `options`, `allow_custom`, and `suggested_answer`.
  - TUI shows questions; click options, enter 0/1–n, or type custom text. Adds status hints and question mode.
  - REPL adds `/auto-answer` to accept the suggested answer; also works from TUI.
  - Human stream (no TUI) prompts on stdin for 0/1–n/custom.
  - Event schema: `QuestionRequested` and `QuestionResolved`; IPC command: `AnswerQuestion { question_id, selection }`.
  - Runtime wires pending questions through supervisor; CLI provides `submit_question_answer` and `submit_suggested_answer`.
  - Docs updated with schemas and IPC examples; `ask_question` included in approval policy.

- **Migration**
  - Orchestrators: handle `QuestionRequested` and respond with `AnswerQuestion` (e.g., `{"kind":"suggested"}` or `{"kind":"option","option_id":"..."} or {"kind":"custom","text":"..."}`).
  - Dashboards/wrappers: render questions using `InteractiveQuestionPayload` and show `suggested_answer`.
  - No changes needed for existing flows; `ask_question` does not require approval.

<sup>Written for commit db476d0c983ff8933c793d1a59c11115b465d40d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

