### PR TITLE
feat: enhance user event preview and at-mention handling

### DIFF
--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -113,6 +113,7 @@ mod theme {
     pub const BG: Color = Color::Rgb(22, 22, 28);
     pub const SURFACE: Color = Color::Rgb(32, 32, 42);
     pub const BORDER: Color = Color::Rgb(55, 55, 70);
+    pub const MENTION_BG: Color = Color::Rgb(48, 62, 94);
 
     pub const USER: Color = Color::Rgb(56, 189, 248);
     pub const ASSISTANT: Color = Color::Rgb(167, 139, 250);
@@ -205,6 +206,154 @@ fn apply_at_completion(buffer: &str, cursor_char_idx: usize, choice: &str) -> (S
     let new_byte = at_byte + 1 + choice.len();
     let new_char = new_buf[..new_byte.min(new_buf.len())].chars().count();
     (new_buf, new_char)
+}
+
+fn apply_selected_at_completion(
+    workspace_files: &[String],
+    buffer: &str,
+    cursor_char_idx: usize,
+    at_menu_index: usize,
+    append_space: bool,
+) -> Option<(String, usize)> {
+    let at_matches = at_completion_matches(workspace_files, buffer, cursor_char_idx);
+    if at_matches.is_empty() || !at_completion_active(buffer, cursor_char_idx) {
+        return None;
+    }
+
+    let pick = at_menu_index.min(at_matches.len().saturating_sub(1));
+    let choice = at_matches.get(pick)?;
+    let (mut new_buf, mut new_cursor_char_idx) =
+        apply_at_completion(buffer, cursor_char_idx, choice);
+
+    if append_space {
+        let insert_at = cursor_byte_index(&new_buf, new_cursor_char_idx);
+        new_buf.insert(insert_at, ' ');
+        new_cursor_char_idx += 1;
+    }
+
+    Some((new_buf, new_cursor_char_idx))
+}
+
+fn at_mention_char_ranges(buffer: &str) -> Vec<(usize, usize)> {
+    file_mentions::parse_at_mentions(buffer)
+        .into_iter()
+        .map(|(start, end, _)| {
+            let start_char = buffer[..start].chars().count();
+            let end_char = buffer[..end].chars().count();
+            (start_char, end_char)
+        })
+        .collect()
+}
+
+fn completed_at_mention_range_before_cursor(
+    buffer: &str,
+    cursor_char_idx: usize,
+) -> Option<(usize, usize)> {
+    let chars: Vec<char> = buffer.chars().collect();
+    for (start_char, end_char) in at_mention_char_ranges(buffer) {
+        if end_char == cursor_char_idx {
+            return Some((start_char, end_char));
+        }
+        if end_char < chars.len()
+            && end_char + 1 == cursor_char_idx
+            && chars.get(end_char) == Some(&' ')
+        {
+            return Some((start_char, end_char + 1));
+        }
+    }
+    None
+}
+
+fn remove_char_range(buffer: &str, start_char_idx: usize, end_char_idx: usize) -> String {
+    let mut chars: Vec<char> = buffer.chars().collect();
+    chars.drain(start_char_idx..end_char_idx);
+    chars.into_iter().collect()
+}
+
+fn delete_completed_at_mention(buffer: &str, cursor_char_idx: usize) -> Option<(String, usize)> {
+    let (start_char, end_char) = completed_at_mention_range_before_cursor(buffer, cursor_char_idx)?;
+    Some((remove_char_range(buffer, start_char, end_char), start_char))
+}
+
+fn push_styled_run(
+    spans: &mut Vec<Span<'static>>,
+    text: &mut String,
+    current_style: &mut Option<Style>,
+    style: Style,
+    ch: char,
+) {
+    if current_style.as_ref() != Some(&style) && !text.is_empty() {
+        spans.push(Span::styled(
+            std::mem::take(text),
+            current_style.unwrap_or_default(),
+        ));
+    }
+    *current_style = Some(style);
+    text.push(ch);
+}
+
+fn composer_line(buffer: &str, cursor_char_idx: usize) -> Line<'static> {
+    let prompt = Span::styled("❯ ", Style::default().fg(theme::USER).bold());
+    let chars: Vec<char> = buffer.chars().collect();
+    let mention_ranges = at_mention_char_ranges(buffer);
+    let cursor_char_idx = cursor_char_idx.min(chars.len());
+    let mut spans = vec![prompt];
+    let mut run = String::new();
+    let mut run_style: Option<Style> = None;
+
+    for idx in 0..=chars.len() {
+        if idx == cursor_char_idx {
+            let cursor_char = chars.get(idx).copied().unwrap_or(' ');
+            let in_mention = idx < chars.len()
+                && mention_ranges
+                    .iter()
+                    .any(|(start, end)| *start <= idx && idx < *end);
+            let cursor_style = if in_mention {
+                Style::default()
+                    .bg(theme::USER)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+                    .bg(theme::MUTED)
+                    .fg(Color::Black)
+                    .add_modifier(Modifier::BOLD)
+            };
+            push_styled_run(
+                &mut spans,
+                &mut run,
+                &mut run_style,
+                cursor_style,
+                cursor_char,
+            );
+            if idx == chars.len() {
+                break;
+            }
+            continue;
+        }
+
+        let Some(ch) = chars.get(idx).copied() else {
+            break;
+        };
+        let in_mention = mention_ranges
+            .iter()
+            .any(|(start, end)| *start <= idx && idx < *end);
+        let style = if in_mention {
+            Style::default()
+                .fg(theme::TEXT)
+                .bg(theme::MENTION_BG)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme::TEXT)
+        };
+        push_styled_run(&mut spans, &mut run, &mut run_style, style, ch);
+    }
+
+    if !run.is_empty() {
+        spans.push(Span::styled(run, run_style.unwrap_or_default()));
+    }
+
+    Line::from(spans)
 }
 
 /// Entry for the slash panel: either a hardcoded command or a discovered skill.
@@ -1618,7 +1767,8 @@ pub fn run_blocking(
                             } else {
                                 Style::default().fg(theme::TEXT)
                             };
-                            lines.push(Line::from(Span::styled(format!(" @{path}"), st)));
+                            // Show path without @ prefix since @ is already in the buffer
+                            lines.push(Line::from(Span::styled(format!(" {path}"), st)));
                         }
                         if at_matches.len() > n_show {
                             lines.push(Line::from(Span::styled(
@@ -1641,28 +1791,7 @@ pub fn run_blocking(
                     }
                 }
 
-                let prompt = Span::styled("❯ ", Style::default().fg(theme::USER).bold());
-                let before: String = g.input_buffer.chars().take(g.cursor_char_idx).collect();
-                let after: String = g.input_buffer.chars().skip(g.cursor_char_idx).collect();
-                let input_line = Line::from(vec![
-                    prompt,
-                    Span::styled(before, Style::default().fg(theme::TEXT)),
-                    Span::styled(
-                        if after.is_empty() {
-                            " ".into()
-                        } else {
-                            after.chars().next().map(|c| c.to_string()).unwrap_or_default()
-                        },
-                        Style::default()
-                            .bg(theme::MUTED)
-                            .fg(Color::Black)
-                            .add_modifier(Modifier::BOLD),
-                    ),
-                    Span::styled(
-                        after.chars().skip(1).collect::<String>(),
-                        Style::default().fg(theme::TEXT),
-                    ),
-                ]);
+                let input_line = composer_line(&g.input_buffer, g.cursor_char_idx);
 
                 let hint = if g.active_approval.is_some() {
                     Line::from(Span::styled(
@@ -3125,22 +3254,15 @@ pub fn run_blocking(
                             }
                         }
                         (KeyCode::Tab, _) => {
-                            let at_matches = at_completion_matches(
+                            if let Some((buf, cidx)) = apply_selected_at_completion(
                                 &workspace_files,
                                 &g.input_buffer,
                                 g.cursor_char_idx,
-                            );
-                            if !at_matches.is_empty()
-                                && at_completion_active(&g.input_buffer, g.cursor_char_idx)
-                            {
-                                let pick = g.at_menu_index.min(at_matches.len() - 1);
-                                if let Some(choice) = at_matches.get(pick) {
-                                    let cur = g.cursor_char_idx;
-                                    let (buf, cidx) =
-                                        apply_at_completion(&g.input_buffer, cur, choice);
-                                    g.input_buffer = buf;
-                                    g.cursor_char_idx = cidx;
-                                }
+                                g.at_menu_index,
+                                false,
+                            ) {
+                                g.input_buffer = buf;
+                                g.cursor_char_idx = cidx;
                             } else {
                                 let slash_filtered =
                                     filter_slash_entries(&slash_entries, &g.input_buffer);
@@ -3214,6 +3336,17 @@ pub fn run_blocking(
                             }
                         }
                         (KeyCode::Enter, _) => {
+                            if let Some((buf, cidx)) = apply_selected_at_completion(
+                                &workspace_files,
+                                &g.input_buffer,
+                                g.cursor_char_idx,
+                                g.at_menu_index,
+                                true,
+                            ) {
+                                g.input_buffer = buf;
+                                g.cursor_char_idx = cidx;
+                                continue;
+                            }
                             let line = std::mem::take(&mut g.input_buffer);
                             g.cursor_char_idx = 0;
                             g.slash_menu_index = 0;
@@ -3415,11 +3548,18 @@ pub fn run_blocking(
                         }
                         (KeyCode::Backspace, _) => {
                             if g.cursor_char_idx > 0 {
-                                let idx = g.cursor_char_idx;
-                                let mut cs: Vec<char> = g.input_buffer.chars().collect();
-                                cs.remove(idx - 1);
-                                g.input_buffer = cs.into_iter().collect();
-                                g.cursor_char_idx -= 1;
+                                if let Some((buf, cidx)) =
+                                    delete_completed_at_mention(&g.input_buffer, g.cursor_char_idx)
+                                {
+                                    g.input_buffer = buf;
+                                    g.cursor_char_idx = cidx;
+                                } else {
+                                    let idx = g.cursor_char_idx;
+                                    let mut cs: Vec<char> = g.input_buffer.chars().collect();
+                                    cs.remove(idx - 1);
+                                    g.input_buffer = cs.into_iter().collect();
+                                    g.cursor_char_idx -= 1;
+                                }
                                 if slash_panel_visible(&g.input_buffer) {
                                     let f = filter_slash_entries(&slash_entries, &g.input_buffer);
                                     if !f.is_empty() {
@@ -3461,7 +3601,9 @@ pub fn run_blocking(
 #[cfg(test)]
 mod approval_parse_tests {
     use super::{
-        TuiCmd, branch_picker_enter_command, filtered_branch_indices, parse_approval_verdict,
+        TuiCmd, apply_selected_at_completion, branch_picker_enter_command,
+        completed_at_mention_range_before_cursor, composer_line, delete_completed_at_mention,
+        filtered_branch_indices, parse_approval_verdict,
     };
 
     #[test]
@@ -3519,5 +3661,58 @@ mod approval_parse_tests {
         let branches = vec!["alpha".into(), "main".into(), "main-fix".into()];
         let cmd = branch_picker_enter_command(&branches, "mai", 1);
         assert!(matches!(cmd, Some(TuiCmd::SwitchBranch(name)) if name == "main-fix"));
+    }
+
+    #[test]
+    fn enter_accepts_selected_at_mention_without_submitting() {
+        let workspace_files = vec![
+            "crates/cli/src/file_mentions.rs".into(),
+            "crates/cli/src/tui/app.rs".into(),
+        ];
+        let buffer = "check @crates/cli/src/t";
+        let cursor_char_idx = buffer.chars().count();
+
+        let (next_buffer, next_cursor_char_idx) =
+            apply_selected_at_completion(&workspace_files, buffer, cursor_char_idx, 0, true)
+                .expect("active mention should be selectable");
+
+        assert_eq!(next_buffer, "check @crates/cli/src/tui/app.rs ");
+        assert_eq!(next_cursor_char_idx, next_buffer.chars().count());
+    }
+
+    #[test]
+    fn backspace_deletes_completed_at_mention_and_space() {
+        let buffer = "check @crates/cli/src/tui/app.rs ";
+        let cursor_char_idx = buffer.chars().count();
+
+        let (next_buffer, next_cursor_char_idx) =
+            delete_completed_at_mention(buffer, cursor_char_idx)
+                .expect("completed mention should delete as one token");
+
+        assert_eq!(next_buffer, "check ");
+        assert_eq!(next_cursor_char_idx, "check ".chars().count());
+    }
+
+    #[test]
+    fn mention_range_includes_inserted_trailing_space() {
+        let buffer = "check @crates/cli/src/tui/app.rs ";
+        let cursor_char_idx = buffer.chars().count();
+
+        assert_eq!(
+            completed_at_mention_range_before_cursor(buffer, cursor_char_idx),
+            Some((6, buffer.chars().count()))
+        );
+    }
+
+    #[test]
+    fn composer_line_styles_completed_mentions() {
+        let line = composer_line("see @README.md ", 15);
+        let mention_span = line
+            .spans
+            .iter()
+            .find(|span| span.content.contains("@README.md"))
+            .expect("mention span should exist");
+
+        assert_eq!(mention_span.style.bg, Some(super::theme::MENTION_BG));
     }
 }

--- a/crates/common/src/message.rs
+++ b/crates/common/src/message.rs
@@ -137,7 +137,7 @@ impl MessageContent {
                     }
                 }
                 if images > 0 {
-                    if !text.is_empty() {
+                    if !text.is_empty() && !text.chars().last().is_some_and(char::is_whitespace) {
                         text.push(' ');
                     }
                     text.push_str(&format!("[{images} image(s)]"));
@@ -145,6 +145,14 @@ impl MessageContent {
                 text
             }
         }
+    }
+
+    /// Preview for user-authored content. Expanded ` ```file:path ` blocks are compacted back to
+    /// `@path` so the transcript stays readable while the model still receives full file contents.
+    pub fn user_event_preview(&self) -> String {
+        collapse_expanded_file_blocks(&self.event_preview())
+            .trim()
+            .to_string()
     }
 
     /// Plain text only; images become placeholders (for summary prompts).
@@ -173,6 +181,68 @@ impl MessageContent {
             }
         }
     }
+}
+
+fn collapse_expanded_file_blocks(text: &str) -> String {
+    const HEADER: &str = "```file:";
+    let mut out = String::new();
+    let mut rest = text;
+
+    while let Some(start) = rest.find(HEADER) {
+        let (before, after_header_marker) = rest.split_at(start);
+        out.push_str(before);
+
+        let after_header = &after_header_marker[HEADER.len()..];
+        let Some(header_end) = after_header.find('\n') else {
+            out.push_str(after_header_marker);
+            return collapse_excess_blank_lines(&out);
+        };
+
+        let path = after_header[..header_end].trim();
+        let after_body = &after_header[header_end + 1..];
+        let Some(block_end) = after_body.find("\n```") else {
+            out.push_str(after_header_marker);
+            return collapse_excess_blank_lines(&out);
+        };
+
+        trim_trailing_inline_whitespace(&mut out);
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push('@');
+        out.push_str(path);
+        rest = after_body[block_end + "\n```".len()..].trim_start();
+        if !rest.is_empty() {
+            out.push(' ');
+        }
+    }
+
+    out.push_str(rest);
+    collapse_excess_blank_lines(&out)
+}
+
+fn trim_trailing_inline_whitespace(text: &mut String) {
+    let trimmed_len = text.trim_end().len();
+    text.truncate(trimmed_len);
+}
+
+fn collapse_excess_blank_lines(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut newline_run = 0usize;
+
+    for ch in text.chars() {
+        if ch == '\n' {
+            newline_run += 1;
+            if newline_run <= 2 {
+                out.push(ch);
+            }
+        } else {
+            newline_run = 0;
+            out.push(ch);
+        }
+    }
+
+    out
 }
 
 mod message_content_serde {
@@ -281,7 +351,11 @@ impl Message {
     }
 
     pub fn event_preview(&self) -> String {
-        self.content.event_preview()
+        if self.role == Role::User {
+            self.content.user_event_preview()
+        } else {
+            self.content.event_preview()
+        }
     }
 }
 
@@ -336,6 +410,42 @@ mod tests {
         assert!(content.strip_image_paths(&removed));
         assert!(
             matches!(content, MessageContent::Text(text) if text.contains("image processed and removed after send"))
+        );
+    }
+
+    #[test]
+    fn user_event_preview_compacts_expanded_file_blocks() {
+        let msg = Message::user(
+            "\n\n```file:.gitignore\n# content here\n```\n\n\nlearn about this project",
+        );
+
+        assert_eq!(msg.event_preview(), "@.gitignore learn about this project");
+    }
+
+    #[test]
+    fn user_parts_preview_keeps_images_and_compacts_files() {
+        let msg = Message::user_with_parts(vec![
+            ContentPart::Text {
+                text: "See\n\n```file:README.md\nhello\n```\n\n".into(),
+            },
+            ContentPart::Image {
+                media_type: "image/png".into(),
+                path: ".nca/sessions/x/a.png".into(),
+            },
+        ]);
+
+        assert_eq!(msg.event_preview(), "See @README.md [1 image(s)]");
+    }
+
+    #[test]
+    fn user_event_preview_keeps_multiple_mentions_inline() {
+        let msg = Message::user(
+            "compare ```file:Cargo.toml\n[package]\n```\n and ```file:README.md\nhello\n``` please",
+        );
+
+        assert_eq!(
+            msg.event_preview(),
+            "compare @Cargo.toml and @README.md please"
         );
     }
 }

--- a/docs/plans/file-mention-preview-compaction.md
+++ b/docs/plans/file-mention-preview-compaction.md
@@ -1,0 +1,17 @@
+# File Mention Preview Compaction Plan
+
+## Goal
+
+Keep expanded `@file` context in the model payload while showing a compact, human-friendly preview in the transcript.
+
+## Implementation
+
+- Add a shared preview compactor that rewrites expanded ````file:path` fences back to `@path`.
+- Use that compacted preview for user `MessageReceived` events.
+- Keep assistant/tool previews unchanged.
+
+## Validation
+
+- `cargo test -p nca-common`
+- `cargo test -p nca-cli`
+- `cargo build --release`

--- a/docs/plans/tui-mention-chip-ux.md
+++ b/docs/plans/tui-mention-chip-ux.md
@@ -1,0 +1,17 @@
+# TUI Mention Chip UX Plan
+
+## Goal
+
+Make accepted `@` file mentions read like visible chips in the composer and remove them with a single Backspace.
+
+## Implementation
+
+- Render completed `@path` mentions in the composer with a dedicated background color.
+- Add a helper that detects a completed mention immediately before the cursor, including the trailing spacer inserted on selection.
+- Update Backspace to remove the entire mention token in one step before falling back to normal character deletion.
+
+## Validation
+
+- `cargo test -p nca-cli`
+- `cargo build --release`
+- lints on edited files

--- a/docs/plans/tui-mention-enter-selection.md
+++ b/docs/plans/tui-mention-enter-selection.md
@@ -1,0 +1,17 @@
+# TUI Mention Enter Selection Plan
+
+## Goal
+
+Make `Enter` accept the highlighted `@` file mention into the composer without immediately submitting the prompt.
+
+## Implementation
+
+- Add a small helper for applying the selected `@` completion with optional trailing whitespace.
+- Update the composer `Enter` handler to treat an active `@` mention menu as a selection action, not a submit action.
+- Keep `Tab` behavior unchanged aside from reusing the same helper.
+
+## Validation
+
+- `cargo test -p nca-cli`
+- `cargo build --release`
+- lints on edited files


### PR DESCRIPTION
- Added functionality to compact expanded file blocks in user event previews, replacing them with a simplified format (e.g., `@path`).
- Introduced new methods for handling at-mentions, including selection, deletion, and cursor styling in the TUI.
- Updated the composer line rendering to visually distinguish at-mentions with a specific background color.
- Improved whitespace handling in message content to ensure clean formatting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compacts file previews and upgrades at-mention UX in the TUI for faster composing. Enter now accepts the highlighted `@path` without sending, mentions render as chips, and Backspace removes them in one step.

- **New Features**
  - User event previews rewrite expanded ````file:path``` blocks back to `@path` to keep transcripts readable.
  - TUI: Enter/Tab accept the selected file mention; Enter appends a space and does not submit.
  - Composer styles `@path` mentions with a dedicated background and highlights the cursor inside them.
  - Backspace deletes a completed `@path` (and its trailing space) as a single token.

- **Bug Fixes**
  - Prevent extra spaces before image placeholders and collapse excess blank lines in previews.

<sup>Written for commit 3cad1b0ab3502c1951e4b145659464cac7da0c9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

