### PR TITLE
Add custom provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The product surface is the CLI. No desktop wrapper, no Electron, no browser in t
 - Persists session state and event logs under the current workspace.
 - Exposes machine-readable JSON and NDJSON for automation.
 - Spawns child agents with explicit parent/child lineage and optional git worktrees.
-- Uses MiniMax by default, with OpenAI, Anthropic, and OpenRouter support.
+- Uses MiniMax by default, with OpenAI, Anthropic, OpenRouter, and custom endpoint support.
 - Loads built-in tools plus optional MCP tools from config.
 - Sends **native multimodal** (text + image) messages to MiniMax and other vision-capable models.
 - Auto-summarizes long conversations to prevent token overflow.
@@ -252,6 +252,17 @@ Typical environment variables:
 - `OPENAI_API_KEY`
 - `ANTHROPIC_API_KEY`
 - `OPENROUTER_API_KEY`
+- `CUSTOM_PROVIDER_API_KEY` (for custom endpoints)
+
+### Custom Endpoints
+
+Use `/provider` in the TUI and select **"Add custom provider…"** to configure any OpenAI-compatible or Anthropic-compatible endpoint. Or use the `/custom` slash command:
+
+```
+/custom openai https://my-endpoint.example sk-key my-model
+```
+
+See [Providers](docs/documentation/providers.md) for full details.
 
 Provider config is loaded from defaults, then `~/.nca/config.toml`, then `<workspace>/.nca/config.local.toml`, then environment overrides.
 
@@ -312,7 +323,7 @@ Full user-facing documentation lives in [`docs/documentation/`](docs/documentati
 | [Commands](docs/documentation/commands.md) | Complete CLI command and flag reference |
 | [Interactive Mode](docs/documentation/interactive-mode.md) | TUI, REPL, slash commands, keyboard shortcuts |
 | [Configuration](docs/documentation/configuration.md) | Config files, TOML format, and environment variables |
-| [Providers](docs/documentation/providers.md) | LLM provider setup — MiniMax, Anthropic, OpenAI, OpenRouter |
+| [Providers](docs/documentation/providers.md) | LLM provider setup — MiniMax, Anthropic, OpenAI, OpenRouter, Custom |
 | [Tools](docs/documentation/tools.md) | All agent tools — file ops, search, shell, web, and more |
 | [Sessions](docs/documentation/sessions.md) | Session lifecycle, persistence, resume, and management |
 | [Permissions](docs/documentation/permissions.md) | Approval system, permission modes, and safe mode |

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -11,7 +11,7 @@ use crate::tui::{
     git_current_branch, git_list_branches, git_switch_branch, replay_event_log_into_state,
     run_blocking, spawn_tui_bridge,
 };
-use nca_common::config::{PermissionMode, ProviderKind};
+use nca_common::config::{PermissionMode, ProviderCompatibility, ProviderKind};
 use nca_common::event::{EndReason, QuestionSelection};
 use nca_core::skills::SkillCatalog;
 use nca_runtime::memory_store::MemoryStore;
@@ -415,6 +415,13 @@ impl Repl {
         p: ProviderKind,
         out: ReplOutput<'_>,
     ) -> anyhow::Result<()> {
+        if p == ProviderKind::Custom && self.runtime.config().provider.custom.base_url.trim().is_empty()
+        {
+            out.eprintln(
+                "[provider] custom provider is not configured yet; run /provider → \"Add custom provider…\", or: /custom <openai|anthropic> <base-url> [api-key] [model]",
+            );
+            return Ok(());
+        }
         let mut cfg = self.runtime.config().clone();
         cfg.set_default_provider(p);
         match self.runtime.apply_nca_config(cfg) {
@@ -440,6 +447,53 @@ impl Repl {
                 }
             }
             Err(e) => out.eprintln(&format!("[provider] {e}")),
+        }
+        Ok(())
+    }
+
+    /// Save custom provider fields, switch default to Custom, and persist workspace config.
+    async fn persist_custom_provider_config(
+        &mut self,
+        compatibility: ProviderCompatibility,
+        base_url: String,
+        api_key: Option<String>,
+        model: Option<String>,
+        out: ReplOutput<'_>,
+    ) -> anyhow::Result<()> {
+        let mut cfg = self.runtime.config().clone();
+        cfg.set_custom_compatibility(compatibility);
+        cfg.set_provider_base_url(ProviderKind::Custom, base_url);
+        if let Some(k) = api_key.filter(|k| !k.trim().is_empty()) {
+            cfg.set_provider_api_key(ProviderKind::Custom, k);
+        }
+        if let Some(m) = model.filter(|m| !m.trim().is_empty()) {
+            cfg.provider.set_model_for(ProviderKind::Custom, m);
+        }
+        cfg.set_default_provider(ProviderKind::Custom);
+
+        match self.runtime.apply_nca_config(cfg) {
+            Ok(()) => {
+                if let Err(e) = self
+                    .runtime
+                    .config()
+                    .save_workspace_file(self.runtime.workspace_root())
+                {
+                    out.eprintln(&format!("[custom] applied but workspace save failed: {e}"));
+                } else {
+                    out.println(&format!(
+                        "[custom] {} at {} — model {} — saved .nca/config.local.toml",
+                        compatibility.display_name(),
+                        self.runtime.config().provider.custom.base_url,
+                        self.runtime.model()
+                    ));
+                }
+                if let ReplOutput::Tui(st) = out
+                    && let Ok(mut g) = st.lock()
+                {
+                    g.model = self.runtime.model().to_string();
+                }
+            }
+            Err(e) => out.eprintln(&format!("[custom] {e}")),
         }
         Ok(())
     }
@@ -538,6 +592,7 @@ impl Repl {
                     "  /models            Browse and select models".into(),
                     "  /connect           Connect LLM provider".into(),
                     "  /provider [name]   Default provider".into(),
+                    "  /custom            Configure custom endpoint".into(),
                     "  /apikey <p> <key>  Store provider API key".into(),
                     "  /model [name]      Set active model".into(),
                     "  /editor [seed]     Open external editor".into(),
@@ -1097,7 +1152,7 @@ impl Repl {
             }
             "/config" => {
                 let config = self.runtime.config();
-                let lines = vec![
+                let mut lines = vec![
                     format!("Provider:    {}", config.provider.default.display_name()),
                     format!("Model:       {}", self.runtime.model()),
                     format!("Permission:  {:?}", self.runtime.permission_mode()),
@@ -1107,11 +1162,14 @@ impl Repl {
                     format!("Max tokens:  {}", config.model.max_tokens),
                     String::new(),
                     "Provider endpoints:".into(),
-                    format!("  MiniMax:     {}", config.provider.base_url_for(ProviderKind::MiniMax)),
-                    format!("  OpenAI:      {}", config.provider.base_url_for(ProviderKind::OpenAi)),
-                    format!("  Anthropic:   {}", config.provider.base_url_for(ProviderKind::Anthropic)),
-                    format!("  OpenRouter:  {}", config.provider.base_url_for(ProviderKind::OpenRouter)),
                 ];
+                for provider in ProviderKind::ALL {
+                    lines.push(format!(
+                        "  {:<12} {}",
+                        format!("{}:", provider.display_name()),
+                        config.provider.base_url_for(provider)
+                    ));
+                }
                 if let ReplOutput::Tui(st) = &out {
                     if let Ok(mut g) = st.lock() {
                         g.open_info_modal("config", lines);
@@ -1132,7 +1190,8 @@ impl Repl {
                     );
                 } else {
                     out.println("Connect an LLM provider (non-TUI):");
-                    out.println("  /provider <minimax|openai|anthropic|openrouter>");
+                    out.println("  /provider <minimax|openai|anthropic|openrouter|custom>");
+                    out.println("  /custom <openai|anthropic> <base-url> [api-key] [model]");
                     out.println("  /apikey <provider> <secret>   — save API key to .nca/config.local.toml");
                     out.println("  /model <name>                 — set model after switching provider");
                     out.println(&format!(
@@ -1155,6 +1214,7 @@ impl Repl {
                     "  /connect           OpenCode-style provider picker".into(),
                     "  /models            Browse and select models".into(),
                     "  /provider [name]   Default LLM provider".into(),
+                    "  /custom            Configure custom endpoint".into(),
                     "  /apikey <p> <key>  Store API key for a provider".into(),
                     "  /model [name]      Model for the active provider".into(),
                     "  /editor [seed]     Open external editor".into(),
@@ -1177,22 +1237,96 @@ impl Repl {
                         if let Ok(mut g) = st.lock() {
                             g.open_provider_picker(self.runtime.config().provider.default, false);
                         }
-                        out.println("[provider] choose with ↑↓ + Enter, Esc to cancel");
+                        out.println("[provider] choose with ↑↓ + Enter, Esc cancel, c = custom API help");
                     } else {
                         out.println(&format!(
                             "current default provider: {} (model {})",
                             self.runtime.config().provider.default.display_name(),
                             self.runtime.model()
                         ));
-                        out.println("usage: /provider <minimax|openai|anthropic|openrouter>");
+                        out.println("usage: /provider <minimax|openai|anthropic|openrouter|custom>");
+                        out.println("       /provider add-custom   (TUI: BYO endpoint wizard)");
+                    }
+                } else if rest.eq_ignore_ascii_case("add-custom")
+                    || rest.eq_ignore_ascii_case("custom-wizard")
+                {
+                    if let ReplOutput::Tui(st) = out {
+                        if let Ok(mut g) = st.lock() {
+                            g.open_custom_provider_setup(self.runtime.model().to_string());
+                        }
+                        out.println("[provider] add custom provider wizard opened");
+                    } else {
+                        out.println("Wizard needs the full-screen TUI. Use:");
+                        out.println("  /custom <openai|anthropic> <base-url> [api-key] [model]");
                     }
                 } else if let Some(p) = ProviderKind::from_cli_name(rest)
                     .or_else(|| ProviderKind::parse_display_name(rest))
                 {
                     self.apply_provider_in_session(p, out).await?;
                 } else {
-                    out.eprintln("unknown provider; try: minimax, openai, anthropic, openrouter");
+                    out.eprintln("unknown provider; try: minimax, openai, anthropic, openrouter, custom, add-custom");
                 }
+            }
+            "/custom" => {
+                let mut toks = rest.split_whitespace();
+                let compat_raw = toks.next();
+                let base_url = toks.next();
+                let api_key = toks.next();
+                let model = toks.next();
+                if compat_raw.is_none() || base_url.is_none() {
+                    let custom = &self.runtime.config().provider.custom;
+                    let lines = vec![
+                        format!(
+                            "Compatibility: {}",
+                            custom.compatibility.display_name()
+                        ),
+                        format!(
+                            "Base URL:      {}",
+                            if custom.base_url.trim().is_empty() {
+                                "<not set>"
+                            } else {
+                                custom.base_url.as_str()
+                            }
+                        ),
+                        format!("Model:         {}", custom.model),
+                        format!("API key env:   {}", custom.api_key_env),
+                        format!(
+                            "API key:       {}",
+                            if custom.resolve_api_key().is_some() {
+                                "configured"
+                            } else {
+                                "missing"
+                            }
+                        ),
+                        String::new(),
+                        "usage: /custom <openai|anthropic> <base-url> [api-key] [model]".into(),
+                        "TUI:   /provider → \"Add custom provider…\"".into(),
+                        "example: /custom openai https://sumopod.example sk-test my-model".into(),
+                    ];
+                    if let ReplOutput::Tui(st) = &out {
+                        if let Ok(mut g) = st.lock() {
+                            g.open_info_modal("custom provider", lines);
+                        }
+                    } else {
+                        for line in &lines {
+                            out.println(line);
+                        }
+                    }
+                    return Ok(true);
+                }
+
+                let Some(compatibility) =
+                    ProviderCompatibility::from_cli_name(compat_raw.unwrap_or_default())
+                else {
+                    out.eprintln("compatibility must be `openai` or `anthropic`");
+                    return Ok(true);
+                };
+
+                let base_url = base_url.unwrap_or_default().to_string();
+                let api_key = api_key.map(|s| s.to_string());
+                let model = model.map(|s| s.to_string());
+                self.persist_custom_provider_config(compatibility, base_url, api_key, model, out)
+                    .await?;
             }
             "/apikey" => {
                 let mut toks = rest.split_whitespace();
@@ -1219,7 +1353,7 @@ impl Repl {
                             self.save_provider_api_key(p, key, out).await?;
                         }
                     } else {
-                        out.eprintln("unknown provider; try: minimax, openai, anthropic, openrouter");
+                        out.eprintln("unknown provider; try: minimax, openai, anthropic, openrouter, custom");
                     }
                 } else if let ReplOutput::Tui(st) = out {
                     if let Ok(mut g) = st.lock() {
@@ -1723,16 +1857,56 @@ impl Repl {
                     }
                 }
                 TuiCmd::ApplyDefaultProvider(p) => {
-                    self.apply_provider_in_session(p, ReplOutput::Tui(&tui_state))
-                        .await?;
+                    if p == ProviderKind::Custom
+                        && self.runtime.config().provider.custom.base_url.trim().is_empty()
+                    {
+                        if let Ok(mut g) = tui_state.lock() {
+                            g.open_custom_provider_setup(self.runtime.model().to_string());
+                            g.blocks.push(DisplayBlock::System(
+                                "[provider] add custom provider wizard opened".into(),
+                            ));
+                        }
+                    } else {
+                        self.apply_provider_in_session(p, ReplOutput::Tui(&tui_state))
+                            .await?;
+                    }
+                }
+                TuiCmd::ApplyCustomProviderSetup {
+                    compatibility,
+                    base_url,
+                    api_key,
+                    model,
+                } => {
+                    self.persist_custom_provider_config(
+                        compatibility,
+                        base_url,
+                        Some(api_key),
+                        Some(model),
+                        ReplOutput::Tui(&tui_state),
+                    )
+                    .await?;
+                    if let Ok(mut g) = tui_state.lock() {
+                        g.blocks.push(DisplayBlock::System(
+                            "[custom] provider saved and set as default".into(),
+                        ));
+                    }
                 }
                 TuiCmd::PromptApiKey(p, connect_after_save) => {
                     if let Ok(mut g) = tui_state.lock() {
-                        g.open_api_key_modal(
-                            p,
-                            self.runtime.config().provider.api_key_present_for(p),
-                            connect_after_save,
-                        );
+                        if p == ProviderKind::Custom
+                            && self.runtime.config().provider.custom.base_url.trim().is_empty()
+                        {
+                            g.open_custom_provider_setup(self.runtime.model().to_string());
+                            g.blocks.push(DisplayBlock::System(
+                                "[apikey] configure custom endpoint first (wizard opened)".into(),
+                            ));
+                        } else {
+                            g.open_api_key_modal(
+                                p,
+                                self.runtime.config().provider.api_key_present_for(p),
+                                connect_after_save,
+                            );
+                        }
                     }
                 }
                 TuiCmd::ApplyModel(model_name) => {
@@ -1907,7 +2081,11 @@ impl Repl {
                         .to_string();
                     // Run async validation
                     let result = nca_core::provider::validate::validate_api_key(
-                        provider, &api_key, &base_url,
+                        provider,
+                        &api_key,
+                        &base_url,
+                        (provider == ProviderKind::Custom)
+                            .then_some(self.runtime.config().provider.custom.compatibility),
                     )
                     .await;
                     if let Ok(mut g) = tui_state.lock() {

--- a/crates/cli/src/repl.rs
+++ b/crates/cli/src/repl.rs
@@ -415,7 +415,15 @@ impl Repl {
         p: ProviderKind,
         out: ReplOutput<'_>,
     ) -> anyhow::Result<()> {
-        if p == ProviderKind::Custom && self.runtime.config().provider.custom.base_url.trim().is_empty()
+        if p == ProviderKind::Custom
+            && self
+                .runtime
+                .config()
+                .provider
+                .custom
+                .base_url
+                .trim()
+                .is_empty()
         {
             out.eprintln(
                 "[provider] custom provider is not configured yet; run /provider → \"Add custom provider…\", or: /custom <openai|anthropic> <base-url> [api-key] [model]",
@@ -1858,7 +1866,14 @@ impl Repl {
                 }
                 TuiCmd::ApplyDefaultProvider(p) => {
                     if p == ProviderKind::Custom
-                        && self.runtime.config().provider.custom.base_url.trim().is_empty()
+                        && self
+                            .runtime
+                            .config()
+                            .provider
+                            .custom
+                            .base_url
+                            .trim()
+                            .is_empty()
                     {
                         if let Ok(mut g) = tui_state.lock() {
                             g.open_custom_provider_setup(self.runtime.model().to_string());
@@ -1894,7 +1909,14 @@ impl Repl {
                 TuiCmd::PromptApiKey(p, connect_after_save) => {
                     if let Ok(mut g) = tui_state.lock() {
                         if p == ProviderKind::Custom
-                            && self.runtime.config().provider.custom.base_url.trim().is_empty()
+                            && self
+                                .runtime
+                                .config()
+                                .provider
+                                .custom
+                                .base_url
+                                .trim()
+                                .is_empty()
                         {
                             g.open_custom_provider_setup(self.runtime.model().to_string());
                             g.blocks.push(DisplayBlock::System(

--- a/crates/cli/src/slash_commands.rs
+++ b/crates/cli/src/slash_commands.rs
@@ -22,6 +22,7 @@ pub const SLASH_COMMANDS: &[&str] = &[
     "/doctor",
     "/model",
     "/provider",
+    "/custom",
     "/apikey",
     "/editor",
     "/set-editor",

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -2106,18 +2106,27 @@ pub fn run_blocking(
                             Style::default().fg(theme::MUTED),
                         )));
                     }
-                    for i in scroll..end {
-                        let label = if i < n_builtin {
-                            let p = all[i];
-                            let name = p.display_name();
-                            if p == ProviderKind::Custom {
-                                format!("{name} (BYO endpoint)")
+                    let row_labels: Vec<String> = (0..n)
+                        .map(|i| {
+                            if i < n_builtin {
+                                let p = all[i];
+                                let name = p.display_name();
+                                if p == ProviderKind::Custom {
+                                    format!("{name} (BYO endpoint)")
+                                } else {
+                                    name.to_string()
+                                }
                             } else {
-                                name.to_string()
+                                "Add custom provider…".to_string()
                             }
-                        } else {
-                            "Add custom provider…".to_string()
-                        };
+                        })
+                        .collect();
+                    for (i, label) in row_labels
+                        .iter()
+                        .enumerate()
+                        .skip(scroll)
+                        .take(end.saturating_sub(scroll))
+                    {
                         let st = if i == g.provider_picker_index {
                             Style::default()
                                 .fg(Color::Black)
@@ -3287,72 +3296,71 @@ pub fn run_blocking(
                             (KeyCode::Esc, _) => {
                                 g.close_custom_provider_setup();
                             }
-                            (KeyCode::Enter, _) => {
-                                match g.custom_provider_setup_step {
-                                    CustomProviderSetupStep::Compatibility => {
-                                        g.custom_provider_setup_step = CustomProviderSetupStep::BaseUrl;
-                                        g.custom_setup_input.clear();
-                                    }
-                                    CustomProviderSetupStep::BaseUrl => {
-                                        let t = g.custom_setup_input.trim();
-                                        if t.is_empty() {
-                                            g.push_error(
+                            (KeyCode::Enter, _) => match g.custom_provider_setup_step {
+                                CustomProviderSetupStep::Compatibility => {
+                                    g.custom_provider_setup_step = CustomProviderSetupStep::BaseUrl;
+                                    g.custom_setup_input.clear();
+                                }
+                                CustomProviderSetupStep::BaseUrl => {
+                                    let t = g.custom_setup_input.trim();
+                                    if t.is_empty() {
+                                        g.push_error(
                                                 "[custom] enter a base URL (e.g. https://api.example.com)"
                                                     .into(),
                                             );
-                                        } else {
-                                            g.custom_setup_base_url = t.to_string();
-                                            g.custom_setup_input.clear();
-                                            g.custom_provider_setup_step =
-                                                CustomProviderSetupStep::ApiKey;
-                                        }
-                                    }
-                                    CustomProviderSetupStep::ApiKey => {
-                                        let t = g.custom_setup_input.trim();
-                                        if t.is_empty() {
-                                            g.push_error("[custom] API key is required".into());
-                                        } else {
-                                            g.custom_setup_api_key = t.to_string();
-                                            g.custom_setup_input = g.custom_setup_model_hint.clone();
-                                            if g.custom_setup_input.trim().is_empty() {
-                                                g.custom_setup_input = "custom-model".into();
-                                            }
-                                            g.custom_provider_setup_step =
-                                                CustomProviderSetupStep::Model;
-                                        }
-                                    }
-                                    CustomProviderSetupStep::Model => {
-                                        let t = g.custom_setup_input.trim();
-                                        let model = if t.is_empty() {
-                                            "custom-model".to_string()
-                                        } else {
-                                            t.to_string()
-                                        };
-                                        let compatibility = if g.custom_setup_compat_index == 0 {
-                                            ProviderCompatibility::OpenAi
-                                        } else {
-                                            ProviderCompatibility::Anthropic
-                                        };
-                                        let base_url = g.custom_setup_base_url.clone();
-                                        let api_key = g.custom_setup_api_key.clone();
-                                        g.close_custom_provider_setup();
-                                        drop(g);
-                                        let _ = cmd_tx.send(TuiCmd::ApplyCustomProviderSetup {
-                                            compatibility,
-                                            base_url,
-                                            api_key,
-                                            model,
-                                        });
+                                    } else {
+                                        g.custom_setup_base_url = t.to_string();
+                                        g.custom_setup_input.clear();
+                                        g.custom_provider_setup_step =
+                                            CustomProviderSetupStep::ApiKey;
                                     }
                                 }
-                            }
+                                CustomProviderSetupStep::ApiKey => {
+                                    let t = g.custom_setup_input.trim();
+                                    if t.is_empty() {
+                                        g.push_error("[custom] API key is required".into());
+                                    } else {
+                                        g.custom_setup_api_key = t.to_string();
+                                        g.custom_setup_input = g.custom_setup_model_hint.clone();
+                                        if g.custom_setup_input.trim().is_empty() {
+                                            g.custom_setup_input = "custom-model".into();
+                                        }
+                                        g.custom_provider_setup_step =
+                                            CustomProviderSetupStep::Model;
+                                    }
+                                }
+                                CustomProviderSetupStep::Model => {
+                                    let t = g.custom_setup_input.trim();
+                                    let model = if t.is_empty() {
+                                        "custom-model".to_string()
+                                    } else {
+                                        t.to_string()
+                                    };
+                                    let compatibility = if g.custom_setup_compat_index == 0 {
+                                        ProviderCompatibility::OpenAi
+                                    } else {
+                                        ProviderCompatibility::Anthropic
+                                    };
+                                    let base_url = g.custom_setup_base_url.clone();
+                                    let api_key = g.custom_setup_api_key.clone();
+                                    g.close_custom_provider_setup();
+                                    drop(g);
+                                    let _ = cmd_tx.send(TuiCmd::ApplyCustomProviderSetup {
+                                        compatibility,
+                                        base_url,
+                                        api_key,
+                                        model,
+                                    });
+                                }
+                            },
                             (KeyCode::Up, _)
                                 if matches!(
                                     g.custom_provider_setup_step,
                                     CustomProviderSetupStep::Compatibility
                                 ) =>
                             {
-                                g.custom_setup_compat_index = g.custom_setup_compat_index.saturating_sub(1);
+                                g.custom_setup_compat_index =
+                                    g.custom_setup_compat_index.saturating_sub(1);
                             }
                             (KeyCode::Down, _)
                                 if matches!(
@@ -3395,7 +3403,8 @@ pub fn run_blocking(
                             }
                             (KeyCode::Up, _) => {
                                 if n > 0 {
-                                    g.provider_picker_index = g.provider_picker_index.saturating_sub(1);
+                                    g.provider_picker_index =
+                                        g.provider_picker_index.saturating_sub(1);
                                 }
                                 g.sync_provider_picker_scroll();
                             }
@@ -3438,7 +3447,8 @@ pub fn run_blocking(
                                     g.open_custom_provider_setup(hint);
                                     continue;
                                 }
-                                let p = ProviderKind::ALL[g.provider_picker_index.min(n_builtin - 1)];
+                                let p =
+                                    ProviderKind::ALL[g.provider_picker_index.min(n_builtin - 1)];
                                 g.close_provider_picker();
                                 if for_key {
                                     drop(g);

--- a/crates/cli/src/tui/app.rs
+++ b/crates/cli/src/tui/app.rs
@@ -9,7 +9,8 @@ use crate::tui::connect_modal::{
     row_index_for_selection, selectable_row_indices,
 };
 use crate::tui::state::{
-    ApprovalRequest, DisplayBlock, ModelPickerAction, ModelPickerEntry, TuiSessionState,
+    ApprovalRequest, CustomProviderSetupStep, DisplayBlock, ModelPickerAction, ModelPickerEntry,
+    TuiSessionState,
 };
 use crossterm::{
     cursor::{Hide, MoveToColumn, Show},
@@ -23,7 +24,7 @@ use crossterm::{
         enable_raw_mode,
     },
 };
-use nca_common::config::ProviderKind;
+use nca_common::config::{ProviderCompatibility, ProviderKind};
 use nca_common::event::{BusyState, QuestionSelection};
 use nca_core::approval::suggest_allow_pattern;
 use nca_core::skills::{SkillCatalog, SkillSource};
@@ -100,6 +101,13 @@ pub enum TuiCmd {
     /// Validate an API key for onboarding (provider, api_key).
     /// The repl handler looks up base_url from config.
     ValidateApiKey(ProviderKind, String),
+    /// Apply custom provider settings from the TUI wizard.
+    ApplyCustomProviderSetup {
+        compatibility: ProviderCompatibility,
+        base_url: String,
+        api_key: String,
+        model: String,
+    },
     /// Mark onboarding as complete and persist the flag.
     #[allow(dead_code)]
     CompleteOnboarding,
@@ -132,8 +140,14 @@ const SIDEBAR_MIN_TOTAL_WIDTH: u16 = 110;
 const COMMAND_PALETTE_WIDTH: u16 = 48;
 const COMMAND_PALETTE_MAX_ROWS: usize = 10;
 
+/// Text used for `/command` detection (ignores leading spaces in the composer).
+fn slash_command_buffer(buffer: &str) -> &str {
+    buffer.trim_start()
+}
+
 fn slash_panel_visible(buffer: &str) -> bool {
-    buffer.starts_with('/') && !buffer.contains(' ')
+    let s = slash_command_buffer(buffer);
+    s.starts_with('/') && !s.contains(' ')
 }
 
 fn cursor_byte_index(line: &str, cursor_char_idx: usize) -> usize {
@@ -436,7 +450,8 @@ fn filter_slash_entries<'a>(entries: &'a [SlashEntry], buffer: &str) -> Vec<&'a 
     if !slash_panel_visible(buffer) {
         return Vec::new();
     }
-    let needle = buffer.trim_start_matches('/').to_lowercase();
+    let s = slash_command_buffer(buffer);
+    let needle = s.trim_start_matches('/').to_lowercase();
     entries
         .iter()
         .filter(|e| {
@@ -560,6 +575,10 @@ const PALETTE_CATALOG: &[PaletteRow] = &[
         label: "API key",
         shortcut: "",
     },
+    PaletteRow::Entry {
+        label: "Add custom endpoint",
+        shortcut: "",
+    },
     PaletteRow::Section("System"),
     PaletteRow::Entry {
         label: "View status",
@@ -617,6 +636,7 @@ fn palette_command_for_label(label: &str) -> &'static str {
         "Toggle thinking" => "/thinking",
         "Switch provider" => "/provider",
         "API key" => "/apikey",
+        "Add custom endpoint" => "/provider add-custom",
         "View status" => "/status",
         "Config" => "/config",
         "Doctor" => "/doctor",
@@ -1856,6 +1876,13 @@ pub fn run_blocking(
                         "Enter / 0 = suggested · 1–n = option · click underlined line · /auto-answer · End = transcript bottom (empty input)",
                         Style::default().fg(theme::WARN),
                     ))
+                } else if slash_panel_visible(&g.input_buffer) {
+                    let hint_msg = if slash_filtered.is_empty() {
+                        "No matching /command — try /help or Ctrl+P (palette)"
+                    } else {
+                        "Commands above · ↑↓ select · Tab complete · Ctrl+P palette"
+                    };
+                    Line::from(Span::styled(hint_msg, Style::default().fg(theme::MUTED)))
                 } else if g.input_buffer.is_empty() {
                     Line::from(Span::styled(
                         "Enter send · Tab agent · Ctrl+V image · /image · Ctrl+P palette · Ctrl+Q exit · Ctrl+L clear",
@@ -2054,12 +2081,14 @@ pub fn run_blocking(
 
                 // LLM provider picker (default provider or API-key target).
                 if g.provider_picker_open {
-                    let names: Vec<&'static str> = ProviderKind::ALL
-                        .iter()
-                        .map(|p| p.display_name())
-                        .collect();
-                    let rows = (names.len() as u16).saturating_add(6).max(8);
-                    let popup_area = centered_rect(area, 40, rows);
+                    let all = ProviderKind::ALL;
+                    let n_builtin = all.len();
+                    let n = g.provider_picker_visible_row_count();
+                    let cap = crate::tui::state::TuiSessionState::PROVIDER_PICKER_VISIBLE_ROWS.min(n.max(1));
+                    let scroll = g.provider_picker_scroll.min(n.saturating_sub(1));
+                    let end = (scroll + cap).min(n);
+                    let rows = (cap as u16).saturating_add(9).max(10);
+                    let popup_area = centered_rect(area, 52, rows);
                     let mut lines: Vec<Line> = vec![
                         Line::from(Span::styled(
                             if g.provider_picker_for_api_key {
@@ -2071,7 +2100,24 @@ pub fn run_blocking(
                         )),
                         Line::default(),
                     ];
-                    for (i, name) in names.iter().enumerate() {
+                    if scroll > 0 {
+                        lines.push(Line::from(Span::styled(
+                            "  More above (Up)",
+                            Style::default().fg(theme::MUTED),
+                        )));
+                    }
+                    for i in scroll..end {
+                        let label = if i < n_builtin {
+                            let p = all[i];
+                            let name = p.display_name();
+                            if p == ProviderKind::Custom {
+                                format!("{name} (BYO endpoint)")
+                            } else {
+                                name.to_string()
+                            }
+                        } else {
+                            "Add custom provider…".to_string()
+                        };
                         let st = if i == g.provider_picker_index {
                             Style::default()
                                 .fg(Color::Black)
@@ -2080,11 +2126,17 @@ pub fn run_blocking(
                         } else {
                             Style::default().fg(theme::TEXT)
                         };
-                        lines.push(Line::from(Span::styled(format!(" {name}"), st)));
+                        lines.push(Line::from(Span::styled(format!(" {label}"), st)));
+                    }
+                    if end < n {
+                        lines.push(Line::from(Span::styled(
+                            "  More below (Down)",
+                            Style::default().fg(theme::MUTED),
+                        )));
                     }
                     lines.push(Line::default());
                     lines.push(Line::from(Span::styled(
-                        " Enter confirm · Esc cancel ",
+                        " Enter confirm · Esc cancel · c slash-command help ",
                         Style::default().fg(theme::MUTED),
                     )));
                     frame.render_widget(ClearWidget, popup_area);
@@ -2094,6 +2146,106 @@ pub fn run_blocking(
                                 .borders(Borders::ALL)
                                 .border_style(Style::default().fg(theme::BORDER))
                                 .title(Span::styled(" settings ", Style::default().fg(theme::MUTED))),
+                        )
+                        .style(Style::default().bg(theme::SURFACE))
+                        .wrap(Wrap { trim: false });
+                    frame.render_widget(popup, popup_area);
+                }
+
+                // Add custom provider wizard (`/provider` → Add custom provider…).
+                if g.custom_provider_setup_open {
+                    let rows = 18u16;
+                    let popup_area = centered_rect(area, 72, rows);
+                    let step_title = match g.custom_provider_setup_step {
+                        CustomProviderSetupStep::Compatibility => "Step 1/4 — API compatibility",
+                        CustomProviderSetupStep::BaseUrl => "Step 2/4 — Base URL",
+                        CustomProviderSetupStep::ApiKey => "Step 3/4 — API key",
+                        CustomProviderSetupStep::Model => "Step 4/4 — Model id",
+                    };
+                    let mut lines: Vec<Line> = vec![
+                        Line::from(Span::styled(
+                            step_title,
+                            Style::default().fg(theme::MUTED).add_modifier(Modifier::BOLD),
+                        )),
+                        Line::default(),
+                    ];
+                    match g.custom_provider_setup_step {
+                        CustomProviderSetupStep::Compatibility => {
+                            let opts = [
+                                ("OpenAI-compatible", "POST …/v1/chat/completions (Bearer)"),
+                                ("Anthropic-compatible", "POST …/v1/messages (x-api-key)"),
+                            ];
+                            for (j, (a, b)) in opts.iter().enumerate() {
+                                let st = if j == g.custom_setup_compat_index {
+                                    Style::default()
+                                        .fg(Color::Black)
+                                        .bg(theme::USER)
+                                        .add_modifier(Modifier::BOLD)
+                                } else {
+                                    Style::default().fg(theme::TEXT)
+                                };
+                                lines.push(Line::from(vec![
+                                    Span::styled(format!(" {a}"), st),
+                                    Span::styled(
+                                        format!(" - {b}"),
+                                        Style::default().fg(theme::MUTED),
+                                    ),
+                                ]));
+                            }
+                        }
+                        CustomProviderSetupStep::BaseUrl => {
+                            lines.push(Line::from(Span::styled(
+                                " Example: https://api.example.com (no trailing /v1/…)",
+                                Style::default().fg(theme::MUTED),
+                            )));
+                            lines.push(Line::default());
+                            lines.push(Line::from(Span::styled(
+                                format!(" {}", g.custom_setup_input),
+                                Style::default().fg(theme::TEXT),
+                            )));
+                        }
+                        CustomProviderSetupStep::ApiKey => {
+                            lines.push(Line::from(Span::styled(
+                                " Paste your secret key for this endpoint.",
+                                Style::default().fg(theme::MUTED),
+                            )));
+                            lines.push(Line::default());
+                            let masked = if g.custom_setup_input.is_empty() {
+                                String::new()
+                            } else {
+                                "*".repeat(g.custom_setup_input.chars().count().min(48))
+                            };
+                            lines.push(Line::from(Span::styled(masked, Style::default().fg(theme::TEXT))));
+                        }
+                        CustomProviderSetupStep::Model => {
+                            lines.push(Line::from(Span::styled(
+                                " Model name your host expects (e.g. gpt-4o-mini).",
+                                Style::default().fg(theme::MUTED),
+                            )));
+                            lines.push(Line::default());
+                            lines.push(Line::from(Span::styled(
+                                format!(" {}", g.custom_setup_input),
+                                Style::default().fg(theme::TEXT),
+                            )));
+                        }
+                    }
+                    lines.push(Line::default());
+                    lines.push(Line::from(Span::styled(
+                        match g.custom_provider_setup_step {
+                            CustomProviderSetupStep::Compatibility => {
+                                " Enter confirm · Up/Down · Esc cancel "
+                            }
+                            _ => " Enter confirm · Esc cancel · Backspace edit ",
+                        },
+                        Style::default().fg(theme::MUTED),
+                    )));
+                    frame.render_widget(ClearWidget, popup_area);
+                    let popup = Paragraph::new(Text::from(lines))
+                        .block(
+                            Block::default()
+                                .borders(Borders::ALL)
+                                .border_style(Style::default().fg(theme::BORDER))
+                                .title(Span::styled(" custom provider ", Style::default().fg(theme::MUTED))),
                         )
                         .style(Style::default().bg(theme::SURFACE))
                         .wrap(Wrap { trim: false });
@@ -2753,6 +2905,7 @@ pub fn run_blocking(
                 Event::Mouse(_) if g.model_picker_open => continue,
                 Event::Mouse(_) if g.connect_modal_open => continue,
                 Event::Mouse(_) if g.api_key_modal_open => continue,
+                Event::Mouse(_) if g.custom_provider_setup_open => continue,
                 Event::Mouse(_) if g.provider_picker_open => continue,
                 Event::Mouse(_) if g.permission_picker_open => continue,
                 Event::Mouse(_) if g.agent_picker_open => continue,
@@ -3129,28 +3282,163 @@ pub fn run_blocking(
                         continue;
                     }
 
+                    if g.custom_provider_setup_open {
+                        match (key.code, key.modifiers) {
+                            (KeyCode::Esc, _) => {
+                                g.close_custom_provider_setup();
+                            }
+                            (KeyCode::Enter, _) => {
+                                match g.custom_provider_setup_step {
+                                    CustomProviderSetupStep::Compatibility => {
+                                        g.custom_provider_setup_step = CustomProviderSetupStep::BaseUrl;
+                                        g.custom_setup_input.clear();
+                                    }
+                                    CustomProviderSetupStep::BaseUrl => {
+                                        let t = g.custom_setup_input.trim();
+                                        if t.is_empty() {
+                                            g.push_error(
+                                                "[custom] enter a base URL (e.g. https://api.example.com)"
+                                                    .into(),
+                                            );
+                                        } else {
+                                            g.custom_setup_base_url = t.to_string();
+                                            g.custom_setup_input.clear();
+                                            g.custom_provider_setup_step =
+                                                CustomProviderSetupStep::ApiKey;
+                                        }
+                                    }
+                                    CustomProviderSetupStep::ApiKey => {
+                                        let t = g.custom_setup_input.trim();
+                                        if t.is_empty() {
+                                            g.push_error("[custom] API key is required".into());
+                                        } else {
+                                            g.custom_setup_api_key = t.to_string();
+                                            g.custom_setup_input = g.custom_setup_model_hint.clone();
+                                            if g.custom_setup_input.trim().is_empty() {
+                                                g.custom_setup_input = "custom-model".into();
+                                            }
+                                            g.custom_provider_setup_step =
+                                                CustomProviderSetupStep::Model;
+                                        }
+                                    }
+                                    CustomProviderSetupStep::Model => {
+                                        let t = g.custom_setup_input.trim();
+                                        let model = if t.is_empty() {
+                                            "custom-model".to_string()
+                                        } else {
+                                            t.to_string()
+                                        };
+                                        let compatibility = if g.custom_setup_compat_index == 0 {
+                                            ProviderCompatibility::OpenAi
+                                        } else {
+                                            ProviderCompatibility::Anthropic
+                                        };
+                                        let base_url = g.custom_setup_base_url.clone();
+                                        let api_key = g.custom_setup_api_key.clone();
+                                        g.close_custom_provider_setup();
+                                        drop(g);
+                                        let _ = cmd_tx.send(TuiCmd::ApplyCustomProviderSetup {
+                                            compatibility,
+                                            base_url,
+                                            api_key,
+                                            model,
+                                        });
+                                    }
+                                }
+                            }
+                            (KeyCode::Up, _)
+                                if matches!(
+                                    g.custom_provider_setup_step,
+                                    CustomProviderSetupStep::Compatibility
+                                ) =>
+                            {
+                                g.custom_setup_compat_index = g.custom_setup_compat_index.saturating_sub(1);
+                            }
+                            (KeyCode::Down, _)
+                                if matches!(
+                                    g.custom_provider_setup_step,
+                                    CustomProviderSetupStep::Compatibility
+                                ) =>
+                            {
+                                if g.custom_setup_compat_index < 1 {
+                                    g.custom_setup_compat_index += 1;
+                                }
+                            }
+                            (KeyCode::Backspace, _)
+                                if !matches!(
+                                    g.custom_provider_setup_step,
+                                    CustomProviderSetupStep::Compatibility
+                                ) =>
+                            {
+                                g.custom_setup_input.pop();
+                            }
+                            (KeyCode::Char(c), KeyModifiers::NONE | KeyModifiers::SHIFT)
+                                if !matches!(
+                                    g.custom_provider_setup_step,
+                                    CustomProviderSetupStep::Compatibility
+                                ) =>
+                            {
+                                g.custom_setup_input.push(c);
+                            }
+                            _ => {}
+                        }
+                        continue;
+                    }
+
                     // Provider picker (settings).
                     if g.provider_picker_open {
-                        let n = ProviderKind::ALL.len();
+                        let n = g.provider_picker_visible_row_count();
+                        let n_builtin = ProviderKind::ALL.len();
                         match (key.code, key.modifiers) {
                             (KeyCode::Esc, _) => {
                                 g.close_provider_picker();
                             }
                             (KeyCode::Up, _) => {
-                                g.provider_picker_index = g.provider_picker_index.saturating_sub(1);
+                                if n > 0 {
+                                    g.provider_picker_index = g.provider_picker_index.saturating_sub(1);
+                                }
+                                g.sync_provider_picker_scroll();
                             }
                             (KeyCode::Down, _) => {
                                 if n > 0 {
                                     g.provider_picker_index = (g.provider_picker_index + 1) % n;
                                 }
+                                g.sync_provider_picker_scroll();
+                            }
+                            (KeyCode::Char('c'), KeyModifiers::NONE | KeyModifiers::SHIFT) => {
+                                g.close_provider_picker();
+                                g.open_info_modal(
+                                    "custom API",
+                                    vec![
+                                        "Use a custom base URL that speaks an OpenAI- or Anthropic-compatible HTTP API."
+                                            .to_string(),
+                                        String::new(),
+                                        "Option A — use this wizard: /provider then choose \"Add custom provider…\"."
+                                            .to_string(),
+                                        String::new(),
+                                        "Option B — composer commands:".to_string(),
+                                        "  /custom openai <base-url> [api-key] [model]".to_string(),
+                                        "  /custom anthropic <base-url> [api-key] [model]".to_string(),
+                                        String::new(),
+                                        "Then pick \"Custom\" in /provider or run /provider custom.".to_string(),
+                                    ],
+                                );
                             }
                             (KeyCode::Enter, _) => {
                                 if n == 0 {
                                     g.close_provider_picker();
                                     continue;
                                 }
-                                let p = ProviderKind::ALL[g.provider_picker_index.min(n - 1)];
                                 let for_key = g.provider_picker_for_api_key;
+                                if g.provider_picker_include_add_row
+                                    && g.provider_picker_index == n_builtin
+                                {
+                                    let hint = g.model.clone();
+                                    g.close_provider_picker();
+                                    g.open_custom_provider_setup(hint);
+                                    continue;
+                                }
+                                let p = ProviderKind::ALL[g.provider_picker_index.min(n_builtin - 1)];
                                 g.close_provider_picker();
                                 if for_key {
                                     drop(g);
@@ -3832,7 +4120,8 @@ mod approval_parse_tests {
     use super::{
         TuiCmd, apply_selected_at_completion, branch_picker_enter_command,
         completed_at_mention_range_before_cursor, composer_line, delete_completed_at_mention,
-        escape_cancels_active_turn, filtered_branch_indices, parse_approval_verdict,
+        escape_cancels_active_turn, filter_slash_entries, filtered_branch_indices,
+        load_slash_entries, parse_approval_verdict,
     };
     use crate::tui::state::TuiSessionState;
     use nca_common::event::BusyState;
@@ -3893,6 +4182,19 @@ mod approval_parse_tests {
         let branches = vec!["alpha".into(), "main".into(), "main-fix".into()];
         let cmd = branch_picker_enter_command(&branches, "mai", 1);
         assert!(matches!(cmd, Some(TuiCmd::SwitchBranch(name)) if name == "main-fix"));
+    }
+
+    #[test]
+    fn slash_filter_cus_includes_custom_commands() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let entries = load_slash_entries(dir.path(), &[]);
+        let filtered = filter_slash_entries(&entries, "/cus");
+        let names: Vec<String> = filtered.iter().map(|e| e.command_str()).collect();
+        assert!(
+            names.iter().any(|n| n == "/custom"),
+            "expected /custom in {:?}",
+            names
+        );
     }
 
     #[test]

--- a/crates/cli/src/tui/connect_modal.rs
+++ b/crates/cli/src/tui/connect_modal.rs
@@ -45,6 +45,12 @@ pub const CONNECT_CATALOG: &[CatalogEntry] = &[
         title: "OpenRouter",
         subtitle: "Multi-model routing (API key)",
     },
+    CatalogEntry {
+        section: ConnectSection::Other,
+        kind: ProviderKind::Custom,
+        title: "Custom",
+        subtitle: "Bring your own endpoint (/provider → Add custom)",
+    },
 ];
 
 #[derive(Debug, Clone)]

--- a/crates/cli/src/tui/onboarding.rs
+++ b/crates/cli/src/tui/onboarding.rs
@@ -24,6 +24,24 @@ type ValidationState = Arc<Mutex<Option<OnboardingValidation>>>;
 
 const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
+fn onboarding_connect_rows(search: &str) -> Vec<ConnectRow> {
+    let mut out = Vec::new();
+    let mut pending_header: Option<&'static str> = None;
+    for row in build_connect_rows(search) {
+        match row {
+            ConnectRow::SectionHeader(label) => pending_header = Some(label),
+            ConnectRow::Provider { kind, .. } if kind == ProviderKind::Custom => {}
+            provider @ ConnectRow::Provider { .. } => {
+                if let Some(label) = pending_header.take() {
+                    out.push(ConnectRow::SectionHeader(label));
+                }
+                out.push(provider);
+            }
+        }
+    }
+    out
+}
+
 /// Runs the onboarding TUI. Returns the updated config with the validated key
 /// and onboarding_completed = true, or an error if the user quits (Ctrl+C).
 pub async fn run_onboarding(config: NcaConfig) -> anyhow::Result<NcaConfig> {
@@ -148,7 +166,10 @@ async fn run_onboarding_inner(
                                 let vs = validation_state.clone();
                                 tokio::spawn(async move {
                                     let result = nca_core::provider::validate::validate_api_key(
-                                        provider, &key_str, &base_url,
+                                        provider,
+                                        &key_str,
+                                        &base_url,
+                                        None,
                                     )
                                     .await;
                                     if let Ok(mut g) = vs.lock() {
@@ -183,7 +204,7 @@ async fn run_onboarding_inner(
                     _ => {}
                 }
             } else if connect_open {
-                let rows = build_connect_rows(&connect_search);
+                let rows = onboarding_connect_rows(&connect_search);
                 let sel_indices = selectable_row_indices(&rows);
                 let n_sel = sel_indices.len();
 
@@ -248,7 +269,7 @@ fn render_connect_modal(f: &mut Frame, area: Rect, search: &str, selected: usize
     let inner = block.inner(modal_rect);
     f.render_widget(block, modal_rect);
 
-    let rows = build_connect_rows(search);
+    let rows = onboarding_connect_rows(search);
     let sel_indices = selectable_row_indices(&rows);
 
     let mut lines = Vec::new();

--- a/crates/cli/src/tui/onboarding.rs
+++ b/crates/cli/src/tui/onboarding.rs
@@ -30,7 +30,10 @@ fn onboarding_connect_rows(search: &str) -> Vec<ConnectRow> {
     for row in build_connect_rows(search) {
         match row {
             ConnectRow::SectionHeader(label) => pending_header = Some(label),
-            ConnectRow::Provider { kind, .. } if kind == ProviderKind::Custom => {}
+            ConnectRow::Provider {
+                kind: ProviderKind::Custom,
+                ..
+            } => {}
             provider @ ConnectRow::Provider { .. } => {
                 if let Some(label) = pending_header.take() {
                     out.push(ConnectRow::SectionHeader(label));
@@ -166,10 +169,7 @@ async fn run_onboarding_inner(
                                 let vs = validation_state.clone();
                                 tokio::spawn(async move {
                                     let result = nca_core::provider::validate::validate_api_key(
-                                        provider,
-                                        &key_str,
-                                        &base_url,
-                                        None,
+                                        provider, &key_str, &base_url, None,
                                     )
                                     .await;
                                     if let Ok(mut g) = vs.lock() {

--- a/crates/cli/src/tui/state.rs
+++ b/crates/cli/src/tui/state.rs
@@ -40,6 +40,15 @@ pub struct ApprovalRequest {
     pub input: String,
 }
 
+/// Steps for the in-TUI “add custom provider” wizard (`/provider` → Add custom provider…).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CustomProviderSetupStep {
+    Compatibility,
+    BaseUrl,
+    ApiKey,
+    Model,
+}
+
 /// One row in the sidebar for a child / sub-agent session.
 #[derive(Debug, Clone)]
 pub struct SubagentRow {
@@ -118,6 +127,21 @@ pub struct TuiSessionState {
     pub provider_picker_index: usize,
     /// When true, picking a row sets `pending_api_key_provider` instead of applying provider.
     pub provider_picker_for_api_key: bool,
+    /// When true, the provider list includes a trailing “Add custom provider…” row (default provider only).
+    pub provider_picker_include_add_row: bool,
+    /// First visible row index into [`ProviderKind::ALL`] when the picker is taller than the terminal.
+    pub provider_picker_scroll: usize,
+    /// Multi-step wizard: OpenAI- vs Anthropic-compatible URL, key, model.
+    pub custom_provider_setup_open: bool,
+    pub custom_provider_setup_step: CustomProviderSetupStep,
+    /// 0 = OpenAI-compatible, 1 = Anthropic-compatible.
+    pub custom_setup_compat_index: usize,
+    /// Current line being edited (base URL, API key, or model id).
+    pub custom_setup_input: String,
+    pub custom_setup_base_url: String,
+    pub custom_setup_api_key: String,
+    /// Default model name when opening the wizard (usually the session model).
+    pub custom_setup_model_hint: String,
     /// After choosing a provider for API key, next non-command line is the secret.
     pub pending_api_key_provider: Option<ProviderKind>,
     /// Selected row when `@` file completion panel is visible.
@@ -234,6 +258,15 @@ impl TuiSessionState {
             provider_picker_open: false,
             provider_picker_index: 0,
             provider_picker_for_api_key: false,
+            provider_picker_include_add_row: false,
+            provider_picker_scroll: 0,
+            custom_provider_setup_open: false,
+            custom_provider_setup_step: CustomProviderSetupStep::Compatibility,
+            custom_setup_compat_index: 0,
+            custom_setup_input: String::new(),
+            custom_setup_base_url: String::new(),
+            custom_setup_api_key: String::new(),
+            custom_setup_model_hint: String::new(),
             pending_api_key_provider: None,
             at_menu_index: 0,
             connect_modal_open: false,
@@ -391,15 +424,64 @@ impl TuiSessionState {
     pub fn open_provider_picker(&mut self, current: ProviderKind, for_api_key: bool) {
         self.provider_picker_open = true;
         self.provider_picker_for_api_key = for_api_key;
+        self.provider_picker_include_add_row = !for_api_key;
+        self.provider_picker_scroll = 0;
         self.provider_picker_index = ProviderKind::ALL
             .iter()
             .position(|p| *p == current)
             .unwrap_or(0);
+        self.sync_provider_picker_scroll();
     }
 
     pub fn close_provider_picker(&mut self) {
         self.provider_picker_open = false;
         self.provider_picker_for_api_key = false;
+        self.provider_picker_include_add_row = false;
+        self.provider_picker_scroll = 0;
+    }
+
+    /// Row count for the open provider picker (built-ins plus optional “Add custom…” row).
+    pub fn provider_picker_visible_row_count(&self) -> usize {
+        ProviderKind::ALL.len() + usize::from(self.provider_picker_include_add_row)
+    }
+
+    /// Max provider rows shown at once (smaller than [`ProviderKind::ALL`] so short terminals can scroll).
+    pub const PROVIDER_PICKER_VISIBLE_ROWS: usize = 4;
+
+    /// Keep [`provider_picker_index`](Self::provider_picker_index) inside the visible window.
+    pub fn sync_provider_picker_scroll(&mut self) {
+        let n = self.provider_picker_visible_row_count();
+        let cap = Self::PROVIDER_PICKER_VISIBLE_ROWS.min(n.max(1));
+        if self.provider_picker_index < self.provider_picker_scroll {
+            self.provider_picker_scroll = self.provider_picker_index;
+        }
+        while self.provider_picker_index >= self.provider_picker_scroll + cap {
+            self.provider_picker_scroll += 1;
+        }
+        let max_scroll = n.saturating_sub(cap);
+        if self.provider_picker_scroll > max_scroll {
+            self.provider_picker_scroll = max_scroll;
+        }
+    }
+
+    pub fn open_custom_provider_setup(&mut self, model_hint: impl Into<String>) {
+        self.custom_provider_setup_open = true;
+        self.custom_provider_setup_step = CustomProviderSetupStep::Compatibility;
+        self.custom_setup_compat_index = 0;
+        self.custom_setup_input.clear();
+        self.custom_setup_base_url.clear();
+        self.custom_setup_api_key.clear();
+        self.custom_setup_model_hint = model_hint.into();
+    }
+
+    pub fn close_custom_provider_setup(&mut self) {
+        self.custom_provider_setup_open = false;
+        self.custom_provider_setup_step = CustomProviderSetupStep::Compatibility;
+        self.custom_setup_compat_index = 0;
+        self.custom_setup_input.clear();
+        self.custom_setup_base_url.clear();
+        self.custom_setup_api_key.clear();
+        self.custom_setup_model_hint.clear();
     }
 
     pub fn set_busy(&mut self, busy: bool) {

--- a/crates/cli/tests/cli_commands.rs
+++ b/crates/cli/tests/cli_commands.rs
@@ -372,9 +372,14 @@ model = "openai/gpt-4o-mini"
     let provider_models = payload["provider_models"]
         .as_array()
         .expect("provider_models array");
-    assert_eq!(provider_models.len(), 4);
+    assert_eq!(provider_models.len(), 5);
     assert!(provider_models.iter().any(|entry| {
         entry["provider"] == "OpenAI" && entry["model"] == "gpt-4o" && entry["selected"] == true
+    }));
+    assert!(provider_models.iter().any(|entry| {
+        entry["provider"] == "Custom"
+            && entry["model"] == "custom-model"
+            && entry["selected"] == false
     }));
 }
 
@@ -412,7 +417,7 @@ model = "claude-3-7-sonnet-latest"
     assert_eq!(payload["provider"], "Anthropic");
     assert_eq!(payload["default_model"], "claude-3-7-sonnet-latest");
     let providers = payload["providers"].as_array().expect("providers array");
-    assert_eq!(providers.len(), 4);
+    assert_eq!(providers.len(), 5);
     assert!(providers.iter().any(|entry| {
         entry["provider"] == "Anthropic"
             && entry["selected"] == true
@@ -420,6 +425,11 @@ model = "claude-3-7-sonnet-latest"
     }));
     assert!(providers.iter().any(|entry| {
         entry["provider"] == "OpenAI"
+            && entry["selected"] == false
+            && entry["api_key_present"] == false
+    }));
+    assert!(providers.iter().any(|entry| {
+        entry["provider"] == "Custom"
             && entry["selected"] == false
             && entry["api_key_present"] == false
     }));

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -217,6 +217,24 @@ impl NcaConfig {
             self.provider.openrouter.app_name = Some(app_name);
         }
 
+        if let Ok(api_key) = env::var("CUSTOM_PROVIDER_API_KEY") {
+            self.provider.custom.api_key = Some(api_key);
+        }
+
+        if let Ok(base_url) = env::var("CUSTOM_PROVIDER_BASE_URL") {
+            self.provider.custom.base_url = base_url;
+        }
+
+        if let Ok(model) = env::var("CUSTOM_PROVIDER_MODEL") {
+            self.provider.custom.model = model;
+        }
+
+        if let Ok(raw) = env::var("CUSTOM_PROVIDER_COMPATIBILITY")
+            && let Some(compatibility) = ProviderCompatibility::from_cli_name(&raw)
+        {
+            self.provider.custom.compatibility = compatibility;
+        }
+
         if let Ok(memory_path) = env::var("NCA_MEMORY_PATH") {
             self.memory.file_path = PathBuf::from(memory_path);
         }
@@ -256,7 +274,23 @@ impl NcaConfig {
             ProviderKind::OpenAi => self.provider.openai.api_key = Some(key),
             ProviderKind::Anthropic => self.provider.anthropic.api_key = Some(key),
             ProviderKind::OpenRouter => self.provider.openrouter.api_key = Some(key),
+            ProviderKind::Custom => self.provider.custom.api_key = Some(key),
         }
+    }
+
+    pub fn set_provider_base_url(&mut self, provider: ProviderKind, base_url: impl Into<String>) {
+        let base_url = base_url.into();
+        match provider {
+            ProviderKind::MiniMax => self.provider.minimax.base_url = base_url,
+            ProviderKind::OpenAi => self.provider.openai.base_url = base_url,
+            ProviderKind::Anthropic => self.provider.anthropic.base_url = base_url,
+            ProviderKind::OpenRouter => self.provider.openrouter.base_url = base_url,
+            ProviderKind::Custom => self.provider.custom.base_url = base_url,
+        }
+    }
+
+    pub fn set_custom_compatibility(&mut self, compatibility: ProviderCompatibility) {
+        self.provider.custom.compatibility = compatibility;
     }
 
     /// Editor command: `NCA_EDITOR`, then `[ui].editor`, then `EDITOR`, then `vim`.
@@ -498,6 +532,7 @@ pub struct ProviderConfig {
     pub openai: OpenAiConfig,
     pub anthropic: AnthropicConfig,
     pub openrouter: OpenRouterConfig,
+    pub custom: CustomProviderConfig,
 }
 
 impl Default for ProviderConfig {
@@ -508,6 +543,7 @@ impl Default for ProviderConfig {
             openai: OpenAiConfig::default(),
             anthropic: AnthropicConfig::default(),
             openrouter: OpenRouterConfig::default(),
+            custom: CustomProviderConfig::default(),
         }
     }
 }
@@ -530,6 +566,9 @@ impl ProviderConfig {
         if let Some(openrouter) = partial.openrouter {
             self.openrouter.merge(openrouter);
         }
+        if let Some(custom) = partial.custom {
+            self.custom.merge(custom);
+        }
     }
 
     pub fn active_model(&self) -> &str {
@@ -538,6 +577,7 @@ impl ProviderConfig {
             ProviderKind::OpenRouter => &self.openrouter.model,
             ProviderKind::Anthropic => &self.anthropic.model,
             ProviderKind::OpenAi => &self.openai.model,
+            ProviderKind::Custom => &self.custom.model,
         }
     }
 
@@ -552,6 +592,7 @@ impl ProviderConfig {
             ProviderKind::OpenRouter => self.openrouter.model = model,
             ProviderKind::Anthropic => self.anthropic.model = model,
             ProviderKind::OpenAi => self.openai.model = model,
+            ProviderKind::Custom => self.custom.model = model,
         }
     }
 
@@ -561,6 +602,7 @@ impl ProviderConfig {
             ProviderKind::OpenRouter => &self.openrouter.model,
             ProviderKind::Anthropic => &self.anthropic.model,
             ProviderKind::OpenAi => &self.openai.model,
+            ProviderKind::Custom => &self.custom.model,
         }
     }
 
@@ -570,6 +612,7 @@ impl ProviderConfig {
             ProviderKind::OpenRouter => &self.openrouter.base_url,
             ProviderKind::Anthropic => &self.anthropic.base_url,
             ProviderKind::OpenAi => &self.openai.base_url,
+            ProviderKind::Custom => &self.custom.base_url,
         }
     }
 
@@ -579,6 +622,7 @@ impl ProviderConfig {
             ProviderKind::OpenRouter => &self.openrouter.api_key_env,
             ProviderKind::Anthropic => &self.anthropic.api_key_env,
             ProviderKind::OpenAi => &self.openai.api_key_env,
+            ProviderKind::Custom => &self.custom.api_key_env,
         }
     }
 
@@ -588,6 +632,7 @@ impl ProviderConfig {
             ProviderKind::OpenRouter => self.openrouter.resolve_api_key().is_some(),
             ProviderKind::Anthropic => self.anthropic.resolve_api_key().is_some(),
             ProviderKind::OpenAi => self.openai.resolve_api_key().is_some(),
+            ProviderKind::Custom => self.custom.resolve_api_key().is_some(),
         }
     }
 
@@ -607,14 +652,16 @@ pub enum ProviderKind {
     OpenRouter,
     Anthropic,
     OpenAi,
+    Custom,
 }
 
 impl ProviderKind {
-    pub const ALL: [ProviderKind; 4] = [
+    pub const ALL: [ProviderKind; 5] = [
         ProviderKind::MiniMax,
         ProviderKind::OpenAi,
         ProviderKind::Anthropic,
         ProviderKind::OpenRouter,
+        ProviderKind::Custom,
     ];
 
     /// Parse user/CLI input (slash commands, TUI pickers).
@@ -624,6 +671,7 @@ impl ProviderKind {
             "openai" | "open-ai" | "gpt" => Some(Self::OpenAi),
             "anthropic" | "claude" => Some(Self::Anthropic),
             "openrouter" | "open-router" => Some(Self::OpenRouter),
+            "custom" => Some(Self::Custom),
             _ => None,
         }
     }
@@ -633,6 +681,7 @@ impl ProviderKind {
             "openrouter" => Self::OpenRouter,
             "anthropic" => Self::Anthropic,
             "openai" => Self::OpenAi,
+            "custom" => Self::Custom,
             _ => Self::MiniMax,
         }
     }
@@ -643,6 +692,7 @@ impl ProviderKind {
             ProviderKind::OpenRouter => "OpenRouter",
             ProviderKind::Anthropic => "Anthropic",
             ProviderKind::OpenAi => "OpenAI",
+            ProviderKind::Custom => "Custom",
         }
     }
 
@@ -652,6 +702,30 @@ impl ProviderKind {
         Self::ALL
             .into_iter()
             .find(|k| k.display_name().eq_ignore_ascii_case(t))
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ProviderCompatibility {
+    OpenAi,
+    Anthropic,
+}
+
+impl ProviderCompatibility {
+    pub fn from_cli_name(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "openai" | "open-ai" => Some(Self::OpenAi),
+            "anthropic" | "claude" => Some(Self::Anthropic),
+            _ => None,
+        }
+    }
+
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::OpenAi => "OpenAI-compatible",
+            Self::Anthropic => "Anthropic-compatible",
+        }
     }
 }
 
@@ -846,6 +920,56 @@ impl OpenRouterConfig {
         }
         if let Some(app_name) = partial.app_name {
             self.app_name = Some(app_name);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomProviderConfig {
+    pub api_key_env: String,
+    pub api_key: Option<String>,
+    pub base_url: String,
+    pub model: String,
+    pub temperature: f32,
+    pub compatibility: ProviderCompatibility,
+}
+
+impl Default for CustomProviderConfig {
+    fn default() -> Self {
+        Self {
+            api_key_env: "CUSTOM_PROVIDER_API_KEY".into(),
+            api_key: None,
+            base_url: String::new(),
+            model: "custom-model".into(),
+            temperature: 0.7,
+            compatibility: ProviderCompatibility::OpenAi,
+        }
+    }
+}
+
+impl CustomProviderConfig {
+    pub fn resolve_api_key(&self) -> Option<String> {
+        resolve_api_key_value(&self.api_key, &self.api_key_env)
+    }
+
+    fn merge(&mut self, partial: PartialCustomProviderConfig) {
+        if let Some(api_key_env) = partial.api_key_env {
+            self.api_key_env = api_key_env;
+        }
+        if let Some(api_key) = partial.api_key {
+            self.api_key = Some(api_key);
+        }
+        if let Some(base_url) = partial.base_url {
+            self.base_url = base_url;
+        }
+        if let Some(model) = partial.model {
+            self.model = model;
+        }
+        if let Some(temperature) = partial.temperature {
+            self.temperature = temperature;
+        }
+        if let Some(compatibility) = partial.compatibility {
+            self.compatibility = compatibility;
         }
     }
 }
@@ -1310,6 +1434,7 @@ struct PartialProviderConfig {
     openai: Option<PartialOpenAiConfig>,
     anthropic: Option<PartialAnthropicConfig>,
     openrouter: Option<PartialOpenRouterConfig>,
+    custom: Option<PartialCustomProviderConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -1348,6 +1473,16 @@ struct PartialOpenRouterConfig {
     temperature: Option<f32>,
     site_url: Option<String>,
     app_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+struct PartialCustomProviderConfig {
+    api_key_env: Option<String>,
+    api_key: Option<String>,
+    base_url: Option<String>,
+    model: Option<String>,
+    temperature: Option<f32>,
+    compatibility: Option<ProviderCompatibility>,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -1500,7 +1635,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_env_supports_openai_anthropic_and_openrouter() {
+    fn apply_env_supports_openai_anthropic_openrouter_and_custom() {
         let _guard = EnvGuard::set(&[
             ("NCA_DEFAULT_PROVIDER", Some("openrouter")),
             ("OPENAI_API_KEY", Some("openai-key")),
@@ -1511,6 +1646,10 @@ mod tests {
             ("OPENROUTER_MODEL", Some("anthropic/claude-3.7-sonnet")),
             ("OPENROUTER_SITE_URL", Some("https://nca.test")),
             ("OPENROUTER_APP_NAME", Some("Native CLI AI")),
+            ("CUSTOM_PROVIDER_API_KEY", Some("custom-key")),
+            ("CUSTOM_PROVIDER_BASE_URL", Some("https://custom.example")),
+            ("CUSTOM_PROVIDER_MODEL", Some("custom-model-x")),
+            ("CUSTOM_PROVIDER_COMPATIBILITY", Some("anthropic")),
         ]);
 
         let mut config = NcaConfig::default();
@@ -1545,6 +1684,16 @@ mod tests {
         assert_eq!(
             config.provider.openrouter.app_name.as_deref(),
             Some("Native CLI AI")
+        );
+        assert_eq!(
+            config.provider.custom.resolve_api_key().as_deref(),
+            Some("custom-key")
+        );
+        assert_eq!(config.provider.custom.base_url, "https://custom.example");
+        assert_eq!(config.provider.custom.model, "custom-model-x");
+        assert_eq!(
+            config.provider.custom.compatibility,
+            ProviderCompatibility::Anthropic
         );
         assert_eq!(config.model.default_model, "anthropic/claude-3.7-sonnet");
     }
@@ -1613,6 +1762,10 @@ mod tests {
             ProviderKind::from_cli_name("openai"),
             Some(ProviderKind::OpenAi)
         );
+        assert_eq!(
+            ProviderKind::from_cli_name("custom"),
+            Some(ProviderKind::Custom)
+        );
         assert_eq!(ProviderKind::from_cli_name("nope"), None);
     }
 
@@ -1655,6 +1808,7 @@ onboarding_completed = true
         config.provider.openai.api_key_env = "__NCA_TEST_NONE__".into();
         config.provider.anthropic.api_key_env = "__NCA_TEST_NONE__".into();
         config.provider.openrouter.api_key_env = "__NCA_TEST_NONE__".into();
+        config.provider.custom.api_key_env = "__NCA_TEST_NONE__".into();
         config
     }
 

--- a/crates/common/src/model_caps.rs
+++ b/crates/common/src/model_caps.rs
@@ -35,6 +35,15 @@ pub fn model_accepts_native_images(kind: ProviderKind, model: &str) -> bool {
                 || m.contains("vision")
                 || m.contains("qwen-vl")
         }
+        ProviderKind::Custom => {
+            m.contains("gpt-4o")
+                || m.contains("gpt-4-turbo")
+                || m.contains("gpt-5")
+                || m.contains("claude-3")
+                || m.contains("claude-4")
+                || m.contains("gemini")
+                || m.contains("vision")
+        }
     }
 }
 

--- a/crates/core/src/provider.rs
+++ b/crates/core/src/provider.rs
@@ -1,5 +1,6 @@
 pub mod anthropic;
 pub mod anthropic_compat;
+pub mod custom;
 pub mod factory;
 pub mod minimax;
 pub mod minimax_vlm;

--- a/crates/core/src/provider/custom.rs
+++ b/crates/core/src/provider/custom.rs
@@ -1,0 +1,262 @@
+use std::path::Path;
+
+use nca_common::config::{CustomProviderConfig, NcaConfig, ProviderCompatibility};
+use nca_common::message::Message;
+use nca_common::tool::ToolDefinition;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+
+use super::anthropic_compat::{
+    anthropic_request_body, map_provider_error as map_anthropic_error, spawn_anthropic_stream,
+};
+use super::openai_compat::{
+    map_provider_error as map_openai_error, openai_request_body, spawn_openai_stream,
+};
+use super::{Provider, ProviderError, StreamChunk};
+
+pub struct CustomProvider {
+    client: reqwest::Client,
+    config: CustomProviderConfig,
+    max_tokens: u32,
+}
+
+impl CustomProvider {
+    pub fn from_config(config: &NcaConfig) -> Result<Self, ProviderError> {
+        let custom = config.provider.custom.clone();
+        let api_key = custom.resolve_api_key().ok_or_else(|| {
+            ProviderError::Configuration(format!(
+                "missing Custom provider API key; set {} or provide `provider.custom.api_key` in config",
+                custom.api_key_env
+            ))
+        })?;
+        if custom.base_url.trim().is_empty() {
+            return Err(ProviderError::Configuration(
+                "missing Custom provider base URL; set `provider.custom.base_url`".into(),
+            ));
+        }
+
+        let mut headers = HeaderMap::new();
+        match custom.compatibility {
+            ProviderCompatibility::OpenAi => {
+                headers.insert(
+                    AUTHORIZATION,
+                    HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|err| {
+                        ProviderError::Configuration(format!(
+                            "failed to build Custom provider authorization header: {err}"
+                        ))
+                    })?,
+                );
+            }
+            ProviderCompatibility::Anthropic => {
+                headers.insert(
+                    AUTHORIZATION,
+                    HeaderValue::from_str(&format!("Bearer {api_key}")).map_err(|err| {
+                        ProviderError::Configuration(format!(
+                            "failed to build Custom provider authorization header: {err}"
+                        ))
+                    })?,
+                );
+                headers.insert(
+                    "x-api-key",
+                    HeaderValue::from_str(&api_key).map_err(|err| {
+                        ProviderError::Configuration(format!(
+                            "failed to build Custom provider x-api-key header: {err}"
+                        ))
+                    })?,
+                );
+                headers.insert("anthropic-version", HeaderValue::from_static("2023-06-01"));
+            }
+        }
+
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .map_err(|err| {
+                ProviderError::Configuration(format!("failed to build HTTP client: {err}"))
+            })?;
+
+        Ok(Self {
+            client,
+            config: custom,
+            max_tokens: config.model.max_tokens,
+        })
+    }
+
+    fn endpoint(&self) -> String {
+        match self.config.compatibility {
+            ProviderCompatibility::OpenAi => format!(
+                "{}/v1/chat/completions",
+                self.config.base_url.trim_end_matches('/')
+            ),
+            ProviderCompatibility::Anthropic => {
+                format!("{}/v1/messages", self.config.base_url.trim_end_matches('/'))
+            }
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for CustomProvider {
+    async fn chat(
+        &self,
+        messages: &[Message],
+        tools: &[ToolDefinition],
+        model: &str,
+        workspace_root: &Path,
+    ) -> Result<tokio::sync::mpsc::Receiver<StreamChunk>, ProviderError> {
+        let model = if model.is_empty() {
+            self.config.model.clone()
+        } else {
+            model.to_string()
+        };
+
+        match self.config.compatibility {
+            ProviderCompatibility::OpenAi => {
+                let body = openai_request_body(
+                    messages,
+                    tools,
+                    &model,
+                    self.max_tokens,
+                    self.config.temperature,
+                    workspace_root,
+                )?;
+
+                let response = self
+                    .client
+                    .post(self.endpoint())
+                    .json(&body)
+                    .send()
+                    .await
+                    .map_err(|err| ProviderError::RequestFailed(err.to_string()))?;
+
+                let status = response.status();
+                if !status.is_success() {
+                    let body_text = response.text().await.unwrap_or_default();
+                    return Err(map_openai_error(status, body_text));
+                }
+
+                Ok(spawn_openai_stream(response, "custom"))
+            }
+            ProviderCompatibility::Anthropic => {
+                let body = anthropic_request_body(
+                    messages,
+                    tools,
+                    &model,
+                    self.max_tokens,
+                    self.config.temperature,
+                    workspace_root,
+                )?;
+
+                let response = self
+                    .client
+                    .post(self.endpoint())
+                    .json(&body)
+                    .send()
+                    .await
+                    .map_err(|err| ProviderError::RequestFailed(err.to_string()))?;
+
+                let status = response.status();
+                if !status.is_success() {
+                    let body_text = response.text().await.unwrap_or_default();
+                    return Err(map_anthropic_error(status, body_text));
+                }
+
+                Ok(spawn_anthropic_stream(response, "custom"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::test_support::{collect_chunks, spawn_sse_server};
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn custom_openai_compatible_provider_streams() {
+        let body = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"Hello \"},\"index\":0,\"finish_reason\":null}]}\n\n",
+            "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2}}\n\n",
+            "data: [DONE]\n\n"
+        )
+        .to_string();
+        let base_url = spawn_sse_server(body, 200, |request| {
+            assert_eq!(request.url(), "/v1/chat/completions");
+        });
+
+        let mut config = NcaConfig::default();
+        config.provider.custom.api_key = Some("custom-test-key".into());
+        config.provider.custom.base_url = base_url;
+        config.provider.custom.compatibility = ProviderCompatibility::OpenAi;
+        config.provider.custom.model = "custom-openai-model".into();
+
+        let provider = CustomProvider::from_config(&config).expect("provider");
+        let stream = provider
+            .chat(
+                &[Message::user("hello")],
+                &[],
+                "",
+                std::path::Path::new("."),
+            )
+            .await
+            .expect("chat stream");
+
+        let chunks = collect_chunks(stream).await;
+        assert!(matches!(&chunks[0], StreamChunk::TextDelta(text) if text == "Hello "));
+        assert!(matches!(
+            &chunks[1],
+            StreamChunk::Usage {
+                input_tokens: 5,
+                output_tokens: 2
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn custom_anthropic_compatible_provider_streams_tools() {
+        let body = concat!(
+            "event: content_block_start\n",
+            "data: {\"content_block\":{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"lookup\"}}\n\n",
+            "event: content_block_delta\n",
+            "data: {\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"path\\\":\\\"src\\\"}\"}}\n\n",
+            "event: content_block_stop\n",
+            "data: {}\n\n",
+            "event: message_delta\n",
+            "data: {\"usage\":{\"output_tokens\":5}}\n\n"
+        )
+        .to_string();
+        let base_url = spawn_sse_server(body, 200, |request| {
+            assert_eq!(request.url(), "/v1/messages");
+        });
+
+        let mut config = NcaConfig::default();
+        config.provider.custom.api_key = Some("custom-test-key".into());
+        config.provider.custom.base_url = base_url;
+        config.provider.custom.compatibility = ProviderCompatibility::Anthropic;
+        config.provider.custom.model = "custom-anthropic-model".into();
+
+        let provider = CustomProvider::from_config(&config).expect("provider");
+        let stream = provider
+            .chat(
+                &[Message::user("hello")],
+                &[ToolDefinition {
+                    name: "lookup".into(),
+                    description: "Lookup a path".into(),
+                    parameters: json!({
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}}
+                    }),
+                }],
+                "",
+                std::path::Path::new("."),
+            )
+            .await
+            .expect("chat stream");
+
+        let chunks = collect_chunks(stream).await;
+        assert!(matches!(
+            &chunks[0],
+            StreamChunk::ToolUse(call) if call.name == "lookup" && call.input == json!({"path":"src"})
+        ));
+    }
+}

--- a/crates/core/src/provider/factory.rs
+++ b/crates/core/src/provider/factory.rs
@@ -1,6 +1,7 @@
 use nca_common::config::{NcaConfig, ProviderKind};
 
 use super::anthropic::AnthropicProvider;
+use super::custom::CustomProvider;
 use super::minimax::MiniMaxProvider;
 use super::openai::OpenAiProvider;
 use super::openrouter::OpenRouterProvider;
@@ -13,6 +14,7 @@ pub fn build_provider(config: &NcaConfig) -> Result<Box<dyn Provider>, ProviderE
         ProviderKind::OpenRouter => Ok(Box::new(OpenRouterProvider::from_config(config)?)),
         ProviderKind::Anthropic => Ok(Box::new(AnthropicProvider::from_config(config)?)),
         ProviderKind::OpenAi => Ok(Box::new(OpenAiProvider::from_config(config)?)),
+        ProviderKind::Custom => Ok(Box::new(CustomProvider::from_config(config)?)),
     }
 }
 
@@ -37,6 +39,10 @@ mod tests {
                 }
                 ProviderKind::OpenRouter => {
                     config.provider.openrouter.api_key = Some("openrouter-key".into());
+                }
+                ProviderKind::Custom => {
+                    config.provider.custom.api_key = Some("custom-key".into());
+                    config.provider.custom.base_url = "https://custom.example".into();
                 }
             }
 

--- a/crates/core/src/provider/validate.rs
+++ b/crates/core/src/provider/validate.rs
@@ -1,6 +1,6 @@
 //! Lightweight API key validation per provider.
 
-use nca_common::config::ProviderKind;
+use nca_common::config::{ProviderCompatibility, ProviderKind};
 
 /// Result of an API key validation attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -22,6 +22,7 @@ pub async fn validate_api_key(
     provider: ProviderKind,
     api_key: &str,
     base_url: &str,
+    compatibility: Option<ProviderCompatibility>,
 ) -> ValidationResult {
     let client = match reqwest::Client::builder()
         .timeout(Duration::from_secs(10))
@@ -54,6 +55,28 @@ pub async fn validate_api_key(
                 .send()
                 .await
         }
+        ProviderKind::Custom => match compatibility.unwrap_or(ProviderCompatibility::OpenAi) {
+            ProviderCompatibility::OpenAi => {
+                let url = format!("{}/v1/models", base_url.trim_end_matches('/'));
+                client
+                    .get(&url)
+                    .header("Authorization", format!("Bearer {api_key}"))
+                    .send()
+                    .await
+            }
+            ProviderCompatibility::Anthropic => {
+                let url = format!("{}/v1/messages", base_url.trim_end_matches('/'));
+                client
+                    .post(&url)
+                    .header("Authorization", format!("Bearer {api_key}"))
+                    .header("x-api-key", api_key)
+                    .header("anthropic-version", "2023-06-01")
+                    .header("content-type", "application/json")
+                    .body(r#"{"max_tokens":1,"messages":[]}"#)
+                    .send()
+                    .await
+            }
+        },
     };
 
     match result {

--- a/crates/runtime/src/model_limits_api.rs
+++ b/crates/runtime/src/model_limits_api.rs
@@ -12,7 +12,7 @@
 //! lookups entirely.
 
 use crate::model_limits::ModelLimits;
-use nca_common::config::{NcaConfig, ProviderKind};
+use nca_common::config::{NcaConfig, ProviderCompatibility, ProviderKind};
 use serde::Deserialize;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -128,6 +128,22 @@ pub async fn resolve_model_limits(config: &NcaConfig, model: &str) -> ModelLimit
             };
             let base = config.provider.openai.base_url.trim_end_matches('/');
             fetch_openai_context(&client, base, &key, model).await
+        }
+        ProviderKind::Custom => {
+            let key = match config.provider.custom.resolve_api_key() {
+                Some(k) => k,
+                None => {
+                    tracing::debug!("context API: custom selected but no API key");
+                    return static_limits;
+                }
+            };
+            let base = config.provider.custom.base_url.trim_end_matches('/');
+            match config.provider.custom.compatibility {
+                ProviderCompatibility::OpenAi => fetch_openai_context(&client, base, &key, model).await,
+                ProviderCompatibility::Anthropic => {
+                    fetch_anthropic_context(&client, base, &key, model).await
+                }
+            }
         }
         ProviderKind::MiniMax => None,
     };
@@ -400,7 +416,32 @@ pub async fn fetch_provider_model_ids(config: &NcaConfig) -> Vec<String> {
         ProviderKind::OpenRouter => fetch_openrouter_model_ids(&client, config).await,
         ProviderKind::Anthropic => fetch_anthropic_model_ids(&client, config).await,
         ProviderKind::OpenAi => fetch_openai_model_ids(&client, config).await,
+        ProviderKind::Custom => fetch_custom_model_ids(&client, config).await,
         ProviderKind::MiniMax => vec!["MiniMax-M2.5".into(), "MiniMax-M2.7".into()],
+    }
+}
+
+async fn fetch_custom_model_ids(client: &reqwest::Client, config: &NcaConfig) -> Vec<String> {
+    let key = match config.provider.custom.resolve_api_key() {
+        Some(k) => k,
+        None => return Vec::new(),
+    };
+    if config.provider.custom.base_url.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let mut shadow = config.clone();
+    match config.provider.custom.compatibility {
+        ProviderCompatibility::OpenAi => {
+            shadow.provider.openai.api_key = Some(key);
+            shadow.provider.openai.base_url = config.provider.custom.base_url.clone();
+            fetch_openai_model_ids(client, &shadow).await
+        }
+        ProviderCompatibility::Anthropic => {
+            shadow.provider.anthropic.api_key = Some(key);
+            shadow.provider.anthropic.base_url = config.provider.custom.base_url.clone();
+            fetch_anthropic_model_ids(client, &shadow).await
+        }
     }
 }
 

--- a/crates/runtime/src/model_limits_api.rs
+++ b/crates/runtime/src/model_limits_api.rs
@@ -139,7 +139,9 @@ pub async fn resolve_model_limits(config: &NcaConfig, model: &str) -> ModelLimit
             };
             let base = config.provider.custom.base_url.trim_end_matches('/');
             match config.provider.custom.compatibility {
-                ProviderCompatibility::OpenAi => fetch_openai_context(&client, base, &key, model).await,
+                ProviderCompatibility::OpenAi => {
+                    fetch_openai_context(&client, base, &key, model).await
+                }
                 ProviderCompatibility::Anthropic => {
                     fetch_anthropic_context(&client, base, &key, model).await
                 }

--- a/docs/documentation/getting-started.md
+++ b/docs/documentation/getting-started.md
@@ -5,7 +5,7 @@
 - **Rust toolchain** — install via [rustup](https://rustup.rs/) (edition 2024, stable channel)
 - **Git** — required for session worktrees and version control integration
 - **ripgrep (`rg`)** — used by the `search_code` tool for fast code search
-- **An LLM API key** — MiniMax (default), Anthropic, OpenAI, or OpenRouter
+- **An LLM API key** — MiniMax (default), Anthropic, OpenAI, OpenRouter, or any compatible endpoint
 
 ## Installation
 

--- a/docs/documentation/interactive-mode.md
+++ b/docs/documentation/interactive-mode.md
@@ -99,6 +99,7 @@ Available agent profiles:
 | `/model [name]` | Set the active model for the session |
 | `/connect` | Open the provider connection picker |
 | `/provider [name]` | Show or set the default LLM provider |
+| `/custom <compat> <url> [key] [model]` | Configure a custom endpoint (OpenAI or Anthropic compatible) |
 | `/apikey <provider> <key>` | Store an API key for a provider |
 
 ### Session and Context

--- a/docs/documentation/providers.md
+++ b/docs/documentation/providers.md
@@ -1,6 +1,6 @@
 # Providers
 
-nca supports four LLM provider backends. You can switch between them at any time via config, environment variables, or the interactive `/connect` and `/provider` commands.
+nca supports five LLM provider backends. You can switch between them at any time via config, environment variables, or the interactive `/connect` and `/provider` commands.
 
 ## Supported Providers
 
@@ -10,6 +10,7 @@ nca supports four LLM provider backends. You can switch between them at any time
 | **Anthropic** | `claude-3-7-sonnet-latest` | Native Anthropic | Direct Anthropic API for Claude models. |
 | **OpenAI** | `gpt-4o-mini` | OpenAI Chat | Standard OpenAI chat completions API. |
 | **OpenRouter** | `openai/gpt-4o-mini` | OpenAI-compatible | Aggregator providing access to 100+ models from multiple providers. |
+| **Custom** | `custom-model` | OpenAI-compatible or Anthropic-compatible | Bring your own endpoint and choose the wire protocol. |
 
 ## MiniMax (Default)
 
@@ -128,6 +129,51 @@ google/gemini-2.0-flash
 meta-llama/llama-3.1-70b-instruct
 ```
 
+## Custom Provider
+
+Use the custom provider when you want `nca` to talk to a non-built-in endpoint such as a self-hosted gateway or a third-party OpenAI-compatible / Anthropic-compatible service.
+
+### Setup
+
+```toml
+[provider]
+default = "custom"
+
+[provider.custom]
+compatibility = "openai"   # or "anthropic"
+base_url = "https://sumopod.example"
+api_key_env = "CUSTOM_PROVIDER_API_KEY"
+model = "my-model"
+temperature = 0.7
+```
+
+Environment variables:
+
+```bash
+export CUSTOM_PROVIDER_API_KEY="your-key"
+export CUSTOM_PROVIDER_BASE_URL="https://sumopod.example"
+export CUSTOM_PROVIDER_MODEL="my-model"
+export CUSTOM_PROVIDER_COMPATIBILITY="openai"
+```
+
+### Interactive Setup
+
+**TUI wizard** — run `/provider`, scroll to **"Add custom provider…"**, and follow the guided steps.
+
+**Slash command:**
+
+```
+/custom openai https://sumopod.example your-key my-model
+/custom anthropic https://my-gateway.example your-key my-model
+```
+
+Notes:
+
+- `compatibility = "openai"` uses `/v1/chat/completions` and `GET /v1/models`
+- `compatibility = "anthropic"` uses `/v1/messages` with `x-api-key` header
+- After setup, use `/model <name>` to switch the configured custom model
+- Press `c` in the provider picker for a quick-reference help card
+
 ## Switching Providers
 
 ### Via CLI Flag
@@ -148,6 +194,9 @@ NCA_MODEL=gpt-4o nca
 ```
 /connect           # Opens provider picker UI
 /provider openai   # Switch default provider
+/provider custom   # Use the configured custom endpoint
+/provider          # TUI picker — select "Add custom provider…" to configure
+/custom openai https://sumopod.example your-key my-model
 /model gpt-4o      # Switch model
 /models            # Browse available models
 ```
@@ -209,6 +258,7 @@ The default environment variable names are:
 | Anthropic | `ANTHROPIC_API_KEY` |
 | OpenAI | `OPENAI_API_KEY` |
 | OpenRouter | `OPENROUTER_API_KEY` |
+| Custom | `CUSTOM_PROVIDER_API_KEY` |
 
 You can change the environment variable name via `api_key_env` in config.
 

--- a/docs/plans/custom-provider-compatibility.md
+++ b/docs/plans/custom-provider-compatibility.md
@@ -1,0 +1,21 @@
+# Custom Provider Compatibility Plan
+
+## Goal
+
+Add a configurable `Custom` provider so users can route `nca` to arbitrary endpoints and choose whether the endpoint speaks an OpenAI-compatible or Anthropic-compatible API.
+
+## Implementation
+
+- Add a `Custom` provider config block in `common::config` with `base_url`, `model`, `api_key`, `api_key_env`, `temperature`, and a compatibility enum.
+- Build a `CustomProvider` in `core` that reuses the existing OpenAI-compatible or Anthropic-compatible request/streaming paths based on the selected compatibility.
+- Extend provider validation and model-catalog lookup so custom providers follow the selected compatibility behavior.
+- Add `Custom` to provider selection surfaces and update the TUI/onboarding flow to collect compatibility, base URL, and API key before activating the provider.
+- Update provider docs so custom endpoint setup is documented alongside the built-in providers.
+
+## Validation
+
+- `cargo test -p nca-common`
+- `cargo test -p nca-core`
+- `cargo test -p nca-runtime`
+- `cargo test -p nca-cli`
+- `cargo build --release`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Custom provider so you can connect to any OpenAI- or Anthropic-compatible endpoint. Includes a TUI wizard, `/custom` command, config/env support, key validation, and docs.

- **New Features**
  - New provider: Custom (OpenAI- or Anthropic-compatible) with model/context limits and model catalog support.
  - CLI: `/custom <openai|anthropic> <base-url> [api-key] [model]`; `/provider custom` now supported.
  - TUI: Provider picker shows “Custom” and “Add custom provider…” wizard; palette entry added; contextual help with keybindings.
  - Config: new `[provider.custom]` block (`compatibility`, `base_url`, `model`, `temperature`, `api_key_env`); env vars `CUSTOM_PROVIDER_API_KEY`, `CUSTOM_PROVIDER_BASE_URL`, `CUSTOM_PROVIDER_MODEL`, `CUSTOM_PROVIDER_COMPATIBILITY`.
  - Validation: API key checks for Custom endpoints (OpenAI or Anthropic wire protocol).
  - Docs/README updated; tests added/updated across CLI, common, core, and runtime.

- **Migration**
  - TUI: run `/provider` → “Add custom provider…” and follow the steps.
  - CLI: run `/custom openai https://your-endpoint key model` (or `anthropic`).
  - Config (optional):
    - `[provider] default = "custom"`
    - `[provider.custom] compatibility = "openai" | "anthropic"; base_url = "..."; model = "..."`.
    - Or set env vars: `CUSTOM_PROVIDER_API_KEY`, `CUSTOM_PROVIDER_BASE_URL`, `CUSTOM_PROVIDER_MODEL`, `CUSTOM_PROVIDER_COMPATIBILITY`.

<sup>Written for commit 97cc35eed8ff72699f03a564fc597ee1c7395f8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

