### PR TITLE
Implement skill resolution and recent skill tracking in tools

### DIFF
--- a/crates/core/src/skills.rs
+++ b/crates/core/src/skills.rs
@@ -90,6 +90,45 @@ impl SkillCatalog {
         skills.sort_by(|left, right| left.command.cmp(&right.command));
         Ok(skills)
     }
+
+    pub fn resolve_requested_commands(
+        workspace_root: &Path,
+        skill_directories: &[PathBuf],
+        requested: &[String],
+    ) -> Result<Vec<String>, String> {
+        let skills = Self::discover(workspace_root, skill_directories)?;
+        let mut resolved = Vec::new();
+        let mut unknown = Vec::new();
+
+        for requested_name in requested {
+            let requested_name = requested_name.trim();
+            if requested_name.is_empty() {
+                continue;
+            }
+
+            if let Some(skill) = skills.iter().find(|skill| skill.command == requested_name) {
+                if !resolved.iter().any(|name| name == &skill.command) {
+                    resolved.push(skill.command.clone());
+                }
+            } else if !unknown.iter().any(|name| name == requested_name) {
+                unknown.push(requested_name.to_string());
+            }
+        }
+
+        if unknown.is_empty() {
+            return Ok(resolved);
+        }
+
+        let available = skills
+            .iter()
+            .map(|skill| skill.command.as_str())
+            .collect::<Vec<_>>();
+        Err(format!(
+            "Unknown skill name(s): {}. Available skills: {}",
+            unknown.join(", "),
+            available.join(", ")
+        ))
+    }
 }
 
 impl Skill {
@@ -897,5 +936,49 @@ Component management and styling...
         let expanded = skill.expanded_body();
         let count = expanded.matches("===== helper.md =====").count();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn resolve_requested_commands_deduplicates_and_preserves_known_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join(".nca/skills/review");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Review\ncommand: review\n---\nReview code.\n",
+        )
+        .unwrap();
+
+        let resolved = SkillCatalog::resolve_requested_commands(
+            dir.path(),
+            &[PathBuf::from(".nca/skills")],
+            &["review".to_string(), " review ".to_string(), String::new()],
+        )
+        .unwrap();
+
+        assert_eq!(resolved, vec!["review"]);
+    }
+
+    #[test]
+    fn resolve_requested_commands_returns_error_for_unknown_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join(".nca/skills/review");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Review\ncommand: review\n---\nReview code.\n",
+        )
+        .unwrap();
+
+        let error = SkillCatalog::resolve_requested_commands(
+            dir.path(),
+            &[PathBuf::from(".nca/skills")],
+            &[String::from("not-real")],
+        )
+        .unwrap_err();
+
+        assert!(error.contains("Unknown skill name(s): not-real"));
+        assert!(error.contains("Available skills:"));
+        assert!(error.contains("review"));
     }
 }

--- a/crates/core/src/tools/invoke_skill.rs
+++ b/crates/core/src/tools/invoke_skill.rs
@@ -1,6 +1,7 @@
 //! Tool that lets the LLM load a skill's full instructions by name.
 
 use crate::skills::SkillCatalog;
+use crate::tools::RecentSkillHints;
 use crate::tools::ToolExecutor;
 use nca_common::tool::{ToolCall, ToolDefinition, ToolResult};
 use std::path::PathBuf;
@@ -8,13 +9,19 @@ use std::path::PathBuf;
 pub struct InvokeSkillTool {
     workspace_root: PathBuf,
     skill_directories: Vec<PathBuf>,
+    recent_skills: RecentSkillHints,
 }
 
 impl InvokeSkillTool {
-    pub fn new(workspace_root: PathBuf, skill_directories: Vec<PathBuf>) -> Self {
+    pub fn new(
+        workspace_root: PathBuf,
+        skill_directories: Vec<PathBuf>,
+        recent_skills: RecentSkillHints,
+    ) -> Self {
         Self {
             workspace_root,
             skill_directories,
+            recent_skills,
         }
     }
 }
@@ -71,6 +78,7 @@ impl ToolExecutor for InvokeSkillTool {
 
         if let Some(skill) = skills.iter().find(|s| s.command == skill_name) {
             let body = skill.expanded_body();
+            self.recent_skills.record(&skill.command);
             ToolResult {
                 call_id: call.id.clone(),
                 success: true,
@@ -105,6 +113,7 @@ mod tests {
         InvokeSkillTool::new(
             workspace.to_path_buf(),
             vec![std::path::PathBuf::from(".nca/skills")],
+            RecentSkillHints::default(),
         )
     }
 
@@ -182,5 +191,29 @@ mod tests {
 
         assert!(!result.success);
         assert!(result.error.unwrap().contains("skill_name is required"));
+    }
+
+    #[tokio::test]
+    async fn records_successfully_loaded_skill_for_follow_up_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join(".nca/skills/review");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Review\ncommand: review\n---\nReview code.\n",
+        )
+        .unwrap();
+
+        let hints = RecentSkillHints::default();
+        let tool = InvokeSkillTool::new(
+            dir.path().to_path_buf(),
+            vec![std::path::PathBuf::from(".nca/skills")],
+            hints.clone(),
+        );
+
+        let result = tool.execute(&make_call("review")).await;
+
+        assert!(result.success);
+        assert_eq!(hints.recent(1), vec!["review"]);
     }
 }

--- a/crates/core/src/tools/mod.rs
+++ b/crates/core/src/tools/mod.rs
@@ -17,6 +17,7 @@ pub mod rename_path;
 pub mod replace_match;
 pub mod run_validation;
 pub mod search;
+pub mod skill_hints;
 pub mod spawn_subagent;
 pub mod types;
 pub mod web_search;
@@ -24,6 +25,7 @@ pub mod write_file;
 
 pub use ask_question::AskQuestionTool;
 pub use invoke_skill::InvokeSkillTool;
+pub use skill_hints::RecentSkillHints;
 
 use nca_common::config::WebConfig;
 use nca_common::tool::{ToolCall, ToolDefinition, ToolResult};

--- a/crates/core/src/tools/skill_hints.rs
+++ b/crates/core/src/tools/skill_hints.rs
@@ -1,0 +1,63 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+
+const MAX_TRACKED_SKILLS: usize = 8;
+
+#[derive(Clone, Default)]
+pub struct RecentSkillHints {
+    inner: Arc<Mutex<VecDeque<String>>>,
+}
+
+impl RecentSkillHints {
+    pub fn record(&self, skill: &str) {
+        let skill = skill.trim();
+        if skill.is_empty() {
+            return;
+        }
+
+        let mut guard = self.inner.lock().expect("recent skill hints lock");
+        if let Some(index) = guard.iter().position(|existing| existing == skill) {
+            guard.remove(index);
+        }
+        guard.push_back(skill.to_string());
+        while guard.len() > MAX_TRACKED_SKILLS {
+            guard.pop_front();
+        }
+    }
+
+    pub fn recent(&self, max: usize) -> Vec<String> {
+        if max == 0 {
+            return Vec::new();
+        }
+
+        let guard = self.inner.lock().expect("recent skill hints lock");
+        let mut out: Vec<String> = guard.iter().rev().take(max).cloned().collect();
+        out.reverse();
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RecentSkillHints;
+
+    #[test]
+    fn record_moves_existing_skill_to_end() {
+        let hints = RecentSkillHints::default();
+        hints.record("review");
+        hints.record("testing");
+        hints.record("review");
+
+        assert_eq!(hints.recent(2), vec!["testing", "review"]);
+    }
+
+    #[test]
+    fn recent_returns_latest_items_in_original_order() {
+        let hints = RecentSkillHints::default();
+        hints.record("a");
+        hints.record("b");
+        hints.record("c");
+
+        assert_eq!(hints.recent(2), vec!["b", "c"]);
+    }
+}

--- a/crates/core/src/tools/spawn_subagent.rs
+++ b/crates/core/src/tools/spawn_subagent.rs
@@ -2,12 +2,14 @@ use nca_common::tool::{ToolCall, ToolDefinition, ToolResult};
 use tokio::sync::{mpsc, oneshot};
 
 use super::ToolExecutor;
+use super::skill_hints::RecentSkillHints;
 
 /// Request sent from the tool to the runtime to spawn a child session.
 #[derive(Debug)]
 pub struct SpawnRequest {
     pub task: String,
     pub focus_files: Vec<String>,
+    pub skills: Vec<String>,
     pub use_worktree: bool,
     pub reply: oneshot::Sender<SpawnResponse>,
 }
@@ -25,11 +27,15 @@ pub struct SpawnResponse {
 
 pub struct SpawnSubagentTool {
     spawn_tx: mpsc::Sender<SpawnRequest>,
+    recent_skills: RecentSkillHints,
 }
 
 impl SpawnSubagentTool {
-    pub fn new(spawn_tx: mpsc::Sender<SpawnRequest>) -> Self {
-        Self { spawn_tx }
+    pub fn new(spawn_tx: mpsc::Sender<SpawnRequest>, recent_skills: RecentSkillHints) -> Self {
+        Self {
+            spawn_tx,
+            recent_skills,
+        }
     }
 }
 
@@ -41,7 +47,10 @@ impl ToolExecutor for SpawnSubagentTool {
             description: "Spawn a sub-agent that runs as a separate session to handle a specific \
                 task in parallel. The sub-agent inherits your conversation context and workspace. \
                 Use this to delegate independent tasks (e.g. creating files, running builds) \
-                to child agents that work in isolated git worktrees."
+                to child agents that work in isolated git worktrees. When the task needs \
+                specialized guidance, include relevant skill names so the child can load them \
+                with invoke_skill before starting. If skills are omitted, the most recently \
+                loaded skill may be inherited automatically."
                 .into(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -54,6 +63,11 @@ impl ToolExecutor for SpawnSubagentTool {
                         "type": "array",
                         "items": { "type": "string" },
                         "description": "Optional list of file paths the sub-agent should focus on."
+                    },
+                    "skills": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional list of exact skill command names from the available skills manifest. The child loads them with invoke_skill before working if they apply."
                     },
                     "use_worktree": {
                         "type": "boolean",
@@ -86,6 +100,22 @@ impl ToolExecutor for SpawnSubagentTool {
             })
             .unwrap_or_default();
 
+        let skills: Vec<String> = call.input["skills"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(str::trim))
+                    .filter(|value| !value.is_empty())
+                    .map(String::from)
+                    .collect()
+            })
+            .unwrap_or_default();
+        let skills = if skills.is_empty() {
+            self.recent_skills.recent(1)
+        } else {
+            skills
+        };
+
         let use_worktree = call.input["use_worktree"].as_bool().unwrap_or(true);
 
         let (reply_tx, reply_rx) = oneshot::channel();
@@ -93,6 +123,7 @@ impl ToolExecutor for SpawnSubagentTool {
         let req = SpawnRequest {
             task,
             focus_files,
+            skills,
             use_worktree,
             reply: reply_tx,
         };
@@ -137,5 +168,94 @@ impl ToolExecutor for SpawnSubagentTool {
                 error: Some("Sub-agent timed out after 600 seconds".into()),
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn definition_exposes_optional_skills_array() {
+        let (tx, _rx) = mpsc::channel(1);
+        let tool = SpawnSubagentTool::new(tx, RecentSkillHints::default());
+
+        let def = tool.definition();
+        assert_eq!(def.name, "spawn_subagent");
+        assert_eq!(def.parameters["properties"]["skills"]["type"], "array");
+        assert_eq!(
+            def.parameters["properties"]["skills"]["items"]["type"],
+            "string"
+        );
+        assert!(def.description.contains("skill names"));
+    }
+
+    #[tokio::test]
+    async fn execute_forwards_skills_in_spawn_request() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let tool = SpawnSubagentTool::new(tx, RecentSkillHints::default());
+        let call = ToolCall {
+            id: "call-1".into(),
+            name: "spawn_subagent".into(),
+            input: serde_json::json!({
+                "task": "Review the parser",
+                "focus_files": ["src/lib.rs"],
+                "skills": ["rust-refactor", "  ", "testing"],
+                "use_worktree": false
+            }),
+        };
+
+        let exec = tokio::spawn(async move { tool.execute(&call).await });
+        let req = rx.recv().await.expect("spawn request");
+        assert_eq!(req.task, "Review the parser");
+        assert_eq!(req.focus_files, vec!["src/lib.rs"]);
+        assert_eq!(req.skills, vec!["rust-refactor", "testing"]);
+        assert!(!req.use_worktree);
+
+        let _ = req.reply.send(SpawnResponse {
+            child_session_id: "child-1".into(),
+            status: "completed".into(),
+            output: "done".into(),
+            workspace: "/tmp/worktree".into(),
+            branch: Some("nca/child-1".into()),
+            worktree_path: Some("/tmp/worktree".into()),
+        });
+
+        let result = exec.await.expect("task join");
+        assert!(result.success);
+        assert!(result.output.contains("\"child_session_id\": \"child-1\""));
+    }
+
+    #[tokio::test]
+    async fn execute_inherits_most_recent_skill_when_skills_are_omitted() {
+        let (tx, mut rx) = mpsc::channel(1);
+        let hints = RecentSkillHints::default();
+        hints.record("review");
+        let tool = SpawnSubagentTool::new(tx, hints);
+        let call = ToolCall {
+            id: "call-2".into(),
+            name: "spawn_subagent".into(),
+            input: serde_json::json!({
+                "task": "Review the parser",
+                "focus_files": ["src/lib.rs"],
+                "use_worktree": false
+            }),
+        };
+
+        let exec = tokio::spawn(async move { tool.execute(&call).await });
+        let req = rx.recv().await.expect("spawn request");
+        assert_eq!(req.skills, vec!["review"]);
+
+        let _ = req.reply.send(SpawnResponse {
+            child_session_id: "child-2".into(),
+            status: "completed".into(),
+            output: "done".into(),
+            workspace: "/tmp/worktree".into(),
+            branch: None,
+            worktree_path: None,
+        });
+
+        let result = exec.await.expect("task join");
+        assert!(result.success);
     }
 }

--- a/crates/runtime/src/supervisor.rs
+++ b/crates/runtime/src/supervisor.rs
@@ -17,8 +17,10 @@ use nca_core::harness::build_system_prompt;
 use nca_core::hooks::{HookEventKind, HookRunner};
 use nca_core::provider::ProviderError;
 use nca_core::provider::factory::build_provider;
+use nca_core::skills::SkillCatalog;
 use nca_core::tools::AskQuestionTool;
 use nca_core::tools::InvokeSkillTool;
+use nca_core::tools::RecentSkillHints;
 use nca_core::tools::ToolRegistry;
 use nca_core::tools::mcp::load_mcp_tools;
 use nca_core::tools::spawn_subagent::{SpawnRequest, SpawnSubagentTool};
@@ -151,8 +153,12 @@ impl Supervisor {
         tools.register(Box::new(crate::bash_tool::RuntimeBashTool::new(pty)));
 
         let (spawn_tx, spawn_rx) = mpsc::channel::<SpawnRequest>(16);
+        let recent_skills = RecentSkillHints::default();
         if !cfg.safe_mode {
-            tools.register(Box::new(SpawnSubagentTool::new(spawn_tx)));
+            tools.register(Box::new(SpawnSubagentTool::new(
+                spawn_tx,
+                recent_skills.clone(),
+            )));
         }
 
         let approval_pending: Option<ApprovalPendingMap>;
@@ -185,6 +191,7 @@ impl Supervisor {
         tools.register(Box::new(InvokeSkillTool::new(
             workspace_root.clone(),
             config.harness.skill_directories.clone(),
+            recent_skills,
         )));
         let session_id = cfg.session_id.unwrap_or_else(generate_session_id);
         let session_store = SessionStore::new(workspace_root.join(&config.session.history_dir));
@@ -1163,6 +1170,32 @@ pub fn spawn_subagent_consumer(
             let event_tx = event_tx.clone();
             let parent_store = SessionStore::new(parent_sessions_dir.clone());
             let parent_summary = parent_summary.clone();
+            let resolved_skills = match SkillCatalog::resolve_requested_commands(
+                &workspace_root,
+                &config.harness.skill_directories,
+                &req.skills,
+            ) {
+                Ok(skills) => skills,
+                Err(error) => {
+                    if let Some(ref tx) = event_tx {
+                        let _ = tx
+                            .send(AgentEvent::Error {
+                                message: format!("Failed to spawn child session: {error}"),
+                            })
+                            .await;
+                    }
+                    let response = nca_core::tools::spawn_subagent::SpawnResponse {
+                        child_session_id: String::new(),
+                        status: "error".into(),
+                        output: error,
+                        workspace: workspace_root.display().to_string(),
+                        branch: None,
+                        worktree_path: None,
+                    };
+                    let _ = req.reply.send(response);
+                    continue;
+                }
+            };
 
             let child_cfg = ChildSessionConfig {
                 parent_session_id: parent_session_id.clone(),
@@ -1172,6 +1205,7 @@ pub fn spawn_subagent_consumer(
                 parent_summary,
                 use_worktree: req.use_worktree,
                 focus_files: req.focus_files,
+                skills: resolved_skills,
             };
 
             tokio::spawn(async move {
@@ -1329,6 +1363,7 @@ pub struct ChildSessionConfig {
     pub parent_summary: String,
     pub use_worktree: bool,
     pub focus_files: Vec<String>,
+    pub skills: Vec<String>,
 }
 
 /// Result of a spawned child session.
@@ -1340,6 +1375,38 @@ pub struct ChildSessionResult {
     pub workspace: String,
     pub branch: Option<String>,
     pub worktree_path: Option<String>,
+}
+
+fn build_subagent_context_prompt(
+    parent_summary: &str,
+    task: &str,
+    focus_files: &[String],
+    skills: &[String],
+) -> String {
+    let mut context_prompt = format!(
+        "You are a sub-agent spawned by a parent session to handle a specific task.\n\n\
+         ## Parent Context\n{}\n\n\
+         ## Your Task\n{}",
+        parent_summary, task
+    );
+
+    if !skills.is_empty() {
+        context_prompt.push_str(
+            "\n\n## Recommended Skills\nLoad these with invoke_skill before starting if they apply:\n",
+        );
+        for skill in skills {
+            context_prompt.push_str(&format!("- {skill}\n"));
+        }
+    }
+
+    if !focus_files.is_empty() {
+        context_prompt.push_str("\n\n## Focus Files\n");
+        for file in focus_files {
+            context_prompt.push_str(&format!("- {file}\n"));
+        }
+    }
+
+    context_prompt
 }
 
 /// Spawn a child session that inherits parent context and runs to completion.
@@ -1405,19 +1472,12 @@ pub async fn spawn_child_session(
             .await;
     }
 
-    let mut context_prompt = format!(
-        "You are a sub-agent spawned by a parent session to handle a specific task.\n\n\
-         ## Parent Context\n{}\n\n\
-         ## Your Task\n{}",
-        cfg.parent_summary, cfg.task
+    let context_prompt = build_subagent_context_prompt(
+        &cfg.parent_summary,
+        &cfg.task,
+        &cfg.focus_files,
+        &cfg.skills,
     );
-
-    if !cfg.focus_files.is_empty() {
-        context_prompt.push_str("\n\n## Focus Files\n");
-        for f in &cfg.focus_files {
-            context_prompt.push_str(&format!("- {f}\n"));
-        }
-    }
 
     let mut handle = sup.take_handle();
     let event_rx = handle.take_event_rx();
@@ -1696,5 +1756,84 @@ mod tests {
 
         let _ = cmd_tx.send(AgentCommand::Shutdown);
         task.abort();
+    }
+
+    #[tokio::test]
+    async fn spawn_subagent_consumer_rejects_unknown_skill_names() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let skill_dir = temp.path().join(".nca/skills/review");
+        std::fs::create_dir_all(&skill_dir).expect("create skill dir");
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Review\ncommand: review\n---\nReview code.\n",
+        )
+        .expect("write skill");
+
+        let (spawn_tx, spawn_rx) = mpsc::channel(1);
+        let handle = spawn_subagent_consumer(
+            spawn_rx,
+            "parent-1".into(),
+            temp.path().to_path_buf(),
+            NcaConfig::default(),
+            vec![],
+            None,
+        );
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        spawn_tx
+            .send(SpawnRequest {
+                task: "Review code".into(),
+                focus_files: vec![],
+                skills: vec!["unknown-skill".into()],
+                use_worktree: false,
+                reply: reply_tx,
+            })
+            .await
+            .expect("send spawn request");
+
+        let response = tokio::time::timeout(std::time::Duration::from_secs(1), reply_rx)
+            .await
+            .expect("reply timeout")
+            .expect("reply channel");
+
+        assert_eq!(response.status, "error");
+        assert!(
+            response
+                .output
+                .contains("Unknown skill name(s): unknown-skill")
+        );
+        assert!(response.output.contains("Available skills:"));
+        assert!(response.output.contains("review"));
+
+        handle.abort();
+    }
+
+    #[test]
+    fn build_subagent_context_prompt_includes_skills_when_present() {
+        let prompt = build_subagent_context_prompt(
+            "Parent discussed parser cleanup.",
+            "Refactor the parser.",
+            &[String::from("src/parser.rs")],
+            &[String::from("rust-refactor"), String::from("testing")],
+        );
+
+        assert!(prompt.contains("## Recommended Skills"));
+        assert!(prompt.contains("Load these with invoke_skill before starting if they apply:"));
+        assert!(prompt.contains("- rust-refactor"));
+        assert!(prompt.contains("- testing"));
+        assert!(prompt.contains("## Focus Files"));
+    }
+
+    #[test]
+    fn build_subagent_context_prompt_omits_skills_section_when_empty() {
+        let prompt = build_subagent_context_prompt(
+            "Parent discussed parser cleanup.",
+            "Refactor the parser.",
+            &[],
+            &[],
+        );
+
+        assert!(!prompt.contains("## Recommended Skills"));
+        assert!(!prompt.contains("invoke_skill before starting"));
     }
 }

--- a/docs/documentation/advanced.md
+++ b/docs/documentation/advanced.md
@@ -28,9 +28,12 @@ The agent calls `spawn_subagent` with:
 {
     "task": "Write comprehensive tests for the authentication module",
     "focus_files": ["src/auth.rs", "src/auth/middleware.rs"],
+    "skills": ["testing", "rust-refactor"],
     "use_worktree": true
 }
 ```
+
+`skills` is optional. When provided, the child session receives those skill names as explicit hints and should load the relevant instructions with `invoke_skill` before starting the delegated task. If `skills` is omitted, `spawn_subagent` can automatically inherit the parent's most recently loaded skill. Unknown skill names are rejected before the child starts, and the error includes the discovered skill commands so the parent can retry with valid names.
 
 ### Git Worktrees
 
@@ -45,6 +48,7 @@ When `use_worktree` is true (default), the child session runs in an isolated git
 - **Permissions:** `bypass-permissions` (no interactive approval needed)
 - **Approvals:** Auto-deny handler (no blocking waits)
 - **Context:** Inherits a summary of the parent's last ~10 messages
+- **Skills:** Can receive explicit skill hints from the parent via `spawn_subagent.skills`
 - **Timeout:** 600 seconds (10 minutes)
 - **Lineage:** Parent and child session IDs are cross-referenced in metadata
 

--- a/docs/documentation/skills.md
+++ b/docs/documentation/skills.md
@@ -92,6 +92,8 @@ Use the rust-patterns skill to review this code.
 
 Or the agent can invoke skills programmatically via the `invoke_skill` tool.
 
+When delegating work to a child session with `spawn_subagent`, the parent can also pass a `skills` list so the sub-agent knows which skill names to load first if they match the task.
+
 ### Slash Command
 
 ```


### PR DESCRIPTION
- Added `resolve_requested_commands` method to `SkillCatalog` for resolving requested skill names, handling duplicates, and returning errors for unknown skills.
- Enhanced `InvokeSkillTool` and `SpawnSubagentTool` to utilize `RecentSkillHints` for tracking recently used skills and passing them to child sessions.
- Updated `spawn_subagent` functionality to accept a list of skills, allowing child sessions to load relevant skills automatically or inherit the most recent one.
- Added tests to ensure correct behavior for skill resolution and recent skill tracking.
- Updated documentation to reflect new features and usage of skills in subagent tasks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds skill resolution and recent-skill tracking so agents and sub-agents load the right guidance automatically. `spawn_subagent` now accepts explicit skills or inherits the most recent; unknown skills are validated early with helpful errors.

- **New Features**
  - Added `SkillCatalog::resolve_requested_commands` to trim, dedupe, and error on unknown skills (includes available commands in the message).
  - Introduced `RecentSkillHints` to track the last N loaded skills.
  - `invoke_skill` records successfully loaded skills into `RecentSkillHints`.
  - `spawn_subagent` accepts an optional `skills` array; if omitted, it inherits the most recent skill. Runtime validates skills and passes them to the child; the child’s context includes “Recommended Skills” with guidance to use `invoke_skill`.

- **Migration**
  - Constructors changed: `InvokeSkillTool::new(..)` and `SpawnSubagentTool::new(..)` now require a shared `RecentSkillHints`.
  - If you send `SpawnRequest` directly, populate the new `skills: Vec<String>` (use `[]` if none).

<sup>Written for commit bd6a22b6136f79c5dd383c8c8cf8ae69fcc50b9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

